### PR TITLE
bridge: propagate panics from runnables

### DIFF
--- a/bridge/cmd/guardiand/main.go
+++ b/bridge/cmd/guardiand/main.go
@@ -199,7 +199,10 @@ func main() {
 		case <-ctx.Done():
 			return nil
 		}
-	})
+	},
+		// It's safer to crash and restart the process in case we encounter a panic,
+		// rather than attempting to reschedule the runnable.
+		supervisor.WithPropagatePanic)
 
 	select {
 	case <-rootCtx.Done():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54 bridge: log submission for cross-submissions to Solana
* #53 bridge: do not resubmit submitted VAAs during aggregation
* #52 bridge: do not log errors for duplicate VAA submissions
* #51 bridge: have all nodes submit VAAs to Solana
* #48 bridge/pkg/solana: retry VAA submission on transient errors
* #47 agent: return gRPC Internal error on submission failure
* #46 bridge: move initial guardian set fetching to pkg/ethereum/watcher.go
* **#45 bridge: propagate panics from runnables**
* #44 bridge: in-place debugging using dlv

Any error that can be recovered by restarting a runnable
can also be recovered from by restarting the entire process.

If we encounter a panic, it's safer to restart the process than
attempting to limp along by restarting the runnable.

We always assume that an external process manager will restart
our process if it crashes. We already rely on this behavior for
libp2p errors which we handle by terminating the process, since libp2p
maintains global state that we can't clear.