### PR TITLE
agent: return gRPC Internal error on submission failure

### DIFF
--- a/solana/agent/src/main.rs
+++ b/solana/agent/src/main.rs
@@ -93,7 +93,7 @@ impl Agent for AgentImpl {
                     Ok(_) => (),
                     Err(e) => {
                         return Err(Status::new(
-                            Code::Unavailable,
+                            Code::Internal,
                             format!("tx sending failed: {}", e),
                         ));
                     }
@@ -106,7 +106,7 @@ impl Agent for AgentImpl {
                     signature: s.to_string(),
                 })),
                 Err(e) => Err(Status::new(
-                    Code::Unavailable,
+                    Code::Internal,
                     format!("tx sending failed: {}", e),
                 )),
             }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54 bridge: log submission for cross-submissions to Solana
* #53 bridge: do not resubmit submitted VAAs during aggregation
* #52 bridge: do not log errors for duplicate VAA submissions
* #51 bridge: have all nodes submit VAAs to Solana
* #48 bridge/pkg/solana: retry VAA submission on transient errors
* **#47 agent: return gRPC Internal error on submission failure**
* #46 bridge: move initial guardian set fetching to pkg/ethereum/watcher.go
* #45 bridge: propagate panics from runnables
* #44 bridge: in-place debugging using dlv

This allows us to distinguish between temporary and permanent failure.

Unless we check the instruction error that occured, we can't know
whether the submission error is a permanent failure and Internal
is therefore the appropriate code to use.