### PR TITLE
bridge: have all nodes submit VAAs to Solana

### DIFF
--- a/bridge/cmd/guardiand/processor.go
+++ b/bridge/cmd/guardiand/processor.go
@@ -268,8 +268,6 @@ func vaaConsensusProcessor(lockC chan *common.ChainLock, setC chan *common.Guard
 						} else {
 							panic(fmt.Sprintf("unknown VAA payload type: %+v", v))
 						}
-					} else if !*unsafeDevMode {
-						panic("not implemented") // TODO
 					} else {
 						logger.Info("quorum not met, doing nothing",
 							zap.String("digest", hash))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54 bridge: log submission for cross-submissions to Solana
* #53 bridge: do not resubmit submitted VAAs during aggregation
* #52 bridge: do not log errors for duplicate VAA submissions
* **#51 bridge: have all nodes submit VAAs to Solana**
* #48 bridge/pkg/solana: retry VAA submission on transient errors
* #47 agent: return gRPC Internal error on submission failure
* #46 bridge: move initial guardian set fetching to pkg/ethereum/watcher.go
* #45 bridge: propagate panics from runnables
* #44 bridge: in-place debugging using dlv

VAAs are deduplicated by the on-chain contracts. For Ethereum,
submission happens outside of the bridge anyway, and for Solana, the
first tx to be confirmed wins. Subsequent attempts to submit it
will fail in preflight, so the fee won't be spent multiple times.

This eliminates the need for leader selection and fixes #20.