### PR TITLE
bridge: do not resubmit submitted VAAs during aggregation

### DIFF
--- a/bridge/cmd/guardiand/processor.go
+++ b/bridge/cmd/guardiand/processor.go
@@ -26,6 +26,7 @@ type (
 		firstObserved time.Time
 		ourVAA        *vaa.VAA
 		signatures    map[ethcommon.Address][]byte
+		submitted     bool
 	}
 
 	vaaMap map[string]*vaaState
@@ -227,7 +228,7 @@ func vaaConsensusProcessor(lockC chan *common.ChainLock, setC chan *common.Guard
 						zap.Int("have_sigs", len(sigs)),
 					)
 
-					if len(sigs) >= quorum {
+					if len(sigs) >= quorum && !state.vaaSignatures[hash].submitted {
 						vaaBytes, err := signed.Marshal()
 						if err != nil {
 							panic(err)
@@ -265,6 +266,8 @@ func vaaConsensusProcessor(lockC chan *common.ChainLock, setC chan *common.Guard
 									zap.String("bytes", hex.EncodeToString(vaaBytes)),
 									zap.Stringer("target_chain", t.TargetChain))
 							}
+
+							state.vaaSignatures[hash].submitted = true
 						} else {
 							panic(fmt.Sprintf("unknown VAA payload type: %+v", v))
 						}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54 bridge: log submission for cross-submissions to Solana
* **#53 bridge: do not resubmit submitted VAAs during aggregation**
* #52 bridge: do not log errors for duplicate VAA submissions
* #51 bridge: have all nodes submit VAAs to Solana
* #48 bridge/pkg/solana: retry VAA submission on transient errors
* #47 agent: return gRPC Internal error on submission failure
* #46 bridge: move initial guardian set fetching to pkg/ethereum/watcher.go
* #45 bridge: propagate panics from runnables
* #44 bridge: in-place debugging using dlv

Fixes #49