### PR TITLE
bridge: use mlockall(2) to prevent pages from being swapped out

### DIFF
--- a/bridge/cmd/guardiand/main.go
+++ b/bridge/cmd/guardiand/main.go
@@ -94,7 +94,7 @@ func main() {
 	// stored in memory and never touch the disk. This is a privileged operation and requires CAP_IPC_LOCK.
 	err := unix.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE)
 	if err != nil {
-		fmt.Printf("Failed to lock memory: %v\n", err)
+		fmt.Printf("Failed to lock memory: %v (CAP_IPC_LOCK missing?)\n", err)
 		os.Exit(1)
 	}
 

--- a/devnet/bridge.yaml
+++ b/devnet/bridge.yaml
@@ -63,6 +63,11 @@ spec:
             - -unsafeDevMode
 #            - -logLevel
 #            - debug
+          securityContext:
+            capabilities:
+              add:
+                # required for syscall.Mlockall
+                - IPC_LOCK
           ports:
             - containerPort: 8999
               name: p2p


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55 bridge: use mlockall(2) to prevent pages from being swapped out**

The extra capability is harmless and is, at worst, a DoS risk.