### PR TITLE
IDE helper scripts for logs and lockups

### DIFF
--- a/.run/guardian-0 logs.run.xml
+++ b/.run/guardian-0 logs.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="guardian-0 logs" type="ShConfigurationType">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/tail.sh" />
+    <option name="SCRIPT_OPTIONS" value="guardian-0" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/guardian-1 logs.run.xml
+++ b/.run/guardian-1 logs.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="guardian-1 logs" type="ShConfigurationType">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/tail.sh" />
+    <option name="SCRIPT_OPTIONS" value="guardian-1" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/guardian-2 logs.run.xml
+++ b/.run/guardian-2 logs.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="guardian-2 logs" type="ShConfigurationType">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/tail.sh" />
+    <option name="SCRIPT_OPTIONS" value="guardian-2" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/guardiand build only.run.xml
+++ b/.run/guardiand build only.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="guardiand build only" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="wormhole" />
+    <working_directory value="$PROJECT_DIR$/bridge" />
+    <kind value="PACKAGE" />
+    <package value="github.com/certusone/wormhole/bridge/cmd/guardiand" />
+    <directory value="$PROJECT_DIR$/" />
+    <option name="run" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/send-lockups.sh.run.xml
+++ b/.run/send-lockups.sh.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="send-lockups.sh" type="ShConfigurationType">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/send-lockups.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/scripts/send-lockups.sh
+++ b/scripts/send-lockups.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+kubectl exec -it -c tests eth-devnet-0 -- npx truffle exec src/send-lockups.js

--- a/scripts/tail.sh
+++ b/scripts/tail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while : ; do
+  kubectl logs --tail=1000 --follow=true $1 guardiand
+  sleep 1
+done


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68 solana: add uncommitted Cargo.lock files
* #67 bridge: migrate cmd/ to cobra
* #66 Remove outdated TODO comments
* #65 bridge: refactor p2p logic into pkg/p2p
* #64 bridge: remove all supervisor.SignalHealthy calls
* #63 bridge: refactor processor logic into pkg/processor
* #62 node.proto stub and dependencies
* #61 devnet: use real account and nonce for send-lockups.js
* #60 bridge: bypass p2p for our own signatures
* #59 bridge: verify LockupObservation signature
* #58 bridge: correctly calculate 2/3+ majority
* **#57 IDE helper scripts for logs and lockups**

The .run folder is a new IntelliJ feature to allow for run configuration
sharing without having to check in .idea.