### PR TITLE
bridge: bypass p2p for our own signatures

### DIFF
--- a/bridge/cmd/guardiand/p2p.go
+++ b/bridge/cmd/guardiand/p2p.go
@@ -223,12 +223,11 @@ func p2p(obsvC chan *gossipv1.LockupObservation, sendC chan []byte) func(ctx con
 				continue
 			}
 
-			// TODO: better way to handle our own sigs?
-			//if envl.GetFrom() == h.ID() {
-			//	logger.Debug("received message from ourselves, ignoring",
-			//		zap.Any("payload", msg.Message))
-			//	continue
-			//}
+			if envl.GetFrom() == h.ID() {
+				logger.Debug("received message from ourselves, ignoring",
+					zap.Any("payload", msg.Message))
+				continue
+			}
 
 			logger.Debug("received message",
 				zap.Any("payload", msg.Message),

--- a/bridge/cmd/guardiand/processor.go
+++ b/bridge/cmd/guardiand/processor.go
@@ -151,6 +151,9 @@ func vaaConsensusProcessor(lockC chan *common.ChainLock, setC chan *common.Guard
 				}
 
 				state.vaaSignatures[hash].ourVAA = v
+
+				// Fast path for our own signature
+				go func() { obsvC <- &obsv }()
 			case m := <-obsvC:
 				// SECURITY: at this point, observations received from the p2p network are fully untrusted (all fields!)
 				//


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68 solana: add uncommitted Cargo.lock files
* #67 bridge: migrate cmd/ to cobra
* #66 Remove outdated TODO comments
* #65 bridge: refactor p2p logic into pkg/p2p
* #64 bridge: remove all supervisor.SignalHealthy calls
* #63 bridge: refactor processor logic into pkg/processor
* #62 node.proto stub and dependencies
* #61 devnet: use real account and nonce for send-lockups.js
* **#60 bridge: bypass p2p for our own signatures**
* #59 bridge: verify LockupObservation signature
* #58 bridge: correctly calculate 2/3+ majority
* #57 IDE helper scripts for logs and lockups

