### PR TITLE
node.proto stub and dependencies

### DIFF
--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -5,10 +5,21 @@
   ./build.sh
 )
 
+(
+  cd third_party/
+  [[ ! -d googleapis ]] && git clone https://github.com/googleapis/googleapis
+  cd googleapis
+  git checkout 24fb9e5d1f37110bfa198189c34324aa3fdb0896
+)
+
 tools/bin/buf protoc \
+  -Iproto \
+  -Ithird_party/googleapis \
   --plugin tools/bin/protoc-gen-go \
   --go_out=bridge/pkg/ proto/**/**/**
 
 tools/bin/buf protoc \
-   --plugin tools/bin/protoc-gen-go-grpc \
-   --go-grpc_out=bridge/pkg/ proto/**/**/**
+  -Iproto \
+  -Ithird_party/googleapis \
+  --plugin tools/bin/protoc-gen-go-grpc \
+  --go-grpc_out=bridge/pkg/ proto/**/**/**

--- a/proto/node/v1/node.proto
+++ b/proto/node/v1/node.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package node.v1;
+
+option go_package = "proto/node/v1;nodev1";
+
+import "google/api/annotations.proto";
+
+service Node {}

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -1,0 +1,1 @@
+googleapis


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68 solana: add uncommitted Cargo.lock files
* #67 bridge: migrate cmd/ to cobra
* #66 Remove outdated TODO comments
* #65 bridge: refactor p2p logic into pkg/p2p
* #64 bridge: remove all supervisor.SignalHealthy calls
* #63 bridge: refactor processor logic into pkg/processor
* **#62 node.proto stub and dependencies**
* #61 devnet: use real account and nonce for send-lockups.js
* #60 bridge: bypass p2p for our own signatures
* #59 bridge: verify LockupObservation signature
* #58 bridge: correctly calculate 2/3+ majority
* #57 IDE helper scripts for logs and lockups

