### PR TITLE
bridge: remove all supervisor.SignalHealthy calls

### DIFF
--- a/bridge/cmd/guardiand/main.go
+++ b/bridge/cmd/guardiand/main.go
@@ -206,7 +206,6 @@ func main() {
 		}
 
 		logger.Info("Started internal services")
-		supervisor.Signal(ctx, supervisor.SignalHealthy)
 
 		select {
 		case <-ctx.Done():

--- a/bridge/cmd/guardiand/p2p.go
+++ b/bridge/cmd/guardiand/p2p.go
@@ -206,8 +206,6 @@ func p2p(obsvC chan *gossipv1.LockupObservation, sendC chan []byte) func(ctx con
 			}
 		}()
 
-		supervisor.Signal(ctx, supervisor.SignalHealthy)
-
 		for {
 			envl, err := sub.Next(ctx)
 			if err != nil {

--- a/bridge/pkg/ethereum/watcher.go
+++ b/bridge/pkg/ethereum/watcher.go
@@ -209,8 +209,6 @@ func (e *EthBridgeWatcher) Run(ctx context.Context) error {
 		}
 	}()
 
-	supervisor.Signal(ctx, supervisor.SignalHealthy)
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/bridge/pkg/processor/processor.go
+++ b/bridge/pkg/processor/processor.go
@@ -100,8 +100,6 @@ func NewProcessor(
 func (p *Processor) Run(ctx context.Context) error {
 	ourAddr := crypto.PubkeyToAddress(p.gk.PublicKey)
 
-	supervisor.Signal(ctx, supervisor.SignalHealthy)
-
 	for {
 		select {
 		case <-ctx.Done():

--- a/bridge/pkg/solana/watcher.go
+++ b/bridge/pkg/solana/watcher.go
@@ -138,7 +138,7 @@ func (e *SolanaBridgeWatcher) Run(ctx context.Context) error {
 					case codes.Internal:
 						// This VAA has already been executed on chain, successfully or not.
 						// TODO: dissect InstructionError in agent and convert this to the proper gRPC code
-						if strings.Contains(st.Message(), "custom program error: 0xb") {  // AlreadyExists
+						if strings.Contains(st.Message(), "custom program error: 0xb") { // AlreadyExists
 							logger.Info("VAA already submitted on-chain, ignoring", zap.Error(err), zap.String("digest", h))
 							break
 						}
@@ -156,8 +156,6 @@ func (e *SolanaBridgeWatcher) Run(ctx context.Context) error {
 			}
 		}
 	}()
-
-	supervisor.Signal(ctx, supervisor.SignalHealthy)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68 solana: add uncommitted Cargo.lock files
* #67 bridge: migrate cmd/ to cobra
* #66 Remove outdated TODO comments
* #65 bridge: refactor p2p logic into pkg/p2p
* **#64 bridge: remove all supervisor.SignalHealthy calls**
* #63 bridge: refactor processor logic into pkg/processor
* #62 node.proto stub and dependencies
* #61 devnet: use real account and nonce for send-lockups.js
* #60 bridge: bypass p2p for our own signatures
* #59 bridge: verify LockupObservation signature
* #58 bridge: correctly calculate 2/3+ majority
* #57 IDE helper scripts for logs and lockups

Supervisor does not back off tasks that failed in a healthy state.

There are a couple places where we rely on supervisor for
application-level backoff, so we always want back-off. The distinction
is meant to enable runnables to implement their own specific back-off
logic, which we don't, so we can safely ignore it.

Fixes #37