### PR TITLE
Remove outdated TODO comments

### DIFF
--- a/bridge/cmd/guardiand/main.go
+++ b/bridge/cmd/guardiand/main.go
@@ -54,9 +54,6 @@ var (
 	rootCtxCancel context.CancelFunc
 )
 
-// TODO: prometheus metrics
-// TODO: telemetry?
-
 // "Why would anyone do this?" are famous last words.
 //
 // We already forcibly override RPC URLs and keys in dev mode to prevent security
@@ -201,8 +198,6 @@ func main() {
 
 	// Run supervisor.
 	supervisor.New(rootCtx, logger, func(ctx context.Context) error {
-		// TODO: use a dependency injection framework like wire?
-
 		if err := supervisor.Run(ctx, "p2p", p2p.Run(
 			obsvC, sendC, priv, *p2pPort, *p2pNetworkID, *p2pBootstrap, *nodeName, rootCtxCancel)); err != nil {
 			return err

--- a/bridge/cmd/guardiand/nodekeys.go
+++ b/bridge/cmd/guardiand/nodekeys.go
@@ -41,7 +41,6 @@ func getOrCreateNodeKey(logger *zap.Logger, path string) (p2pcrypto.PrivKey, err
 		if os.IsNotExist(err) {
 			logger.Info("No node key found, generating a new one...", zap.String("path", path))
 
-			// TODO(leo): what does -1 mean?
 			priv, _, err := p2pcrypto.GenerateKeyPair(p2pcrypto.Ed25519, -1)
 			if err != nil {
 				panic(err)

--- a/bridge/pkg/processor/processor.go
+++ b/bridge/pkg/processor/processor.go
@@ -258,9 +258,6 @@ func (p *Processor) Run(ctx context.Context) error {
 			// a valid signature by an active guardian. We still don't fully trust them, as they may be
 			// byzantine, but now we know who we're dealing with.
 
-			// TODO: timeout/garbage collection for lockup state
-			// TODO: rebroadcast signatures for VAAs that fail to reach consensus
-
 			// []byte isn't hashable in a map. Paying a small extra cost for encoding for easier debugging.
 			hash := hex.EncodeToString(m.Hash)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #68 solana: add uncommitted Cargo.lock files
* #67 bridge: migrate cmd/ to cobra
* **#66 Remove outdated TODO comments**
* #65 bridge: refactor p2p logic into pkg/p2p
* #64 bridge: remove all supervisor.SignalHealthy calls
* #63 bridge: refactor processor logic into pkg/processor
* #62 node.proto stub and dependencies
* #61 devnet: use real account and nonce for send-lockups.js
* #60 bridge: bypass p2p for our own signatures
* #59 bridge: verify LockupObservation signature
* #58 bridge: correctly calculate 2/3+ majority
* #57 IDE helper scripts for logs and lockups

- Metrics tracked in #11.
- Timeout and retransmits covered in #21.
- Dependency injection doesn't make sense at this scale.
- `-1` on `GenerateKeyPair` means "this doesn't make sense for Ed25519,
  please crash if anyone ever tried to generate RSA keys".