### PR TITLE
bridge: fix quorum calculation

### DIFF
--- a/ethereum/contracts/Wormhole.sol
+++ b/ethereum/contracts/Wormhole.sol
@@ -99,9 +99,8 @@ contract Wormhole is ReentrancyGuard {
         GuardianSet memory guardian_set = guardian_sets[vaa_guardian_set_index];
         require(guardian_set.keys.length > 0, "invalid guardian set");
         require(guardian_set.expiration_time == 0 || guardian_set.expiration_time > block.timestamp, "guardian set has expired");
-        // For guardian sets  < 3, the division by 3 evaluates to 0 and the quorum would not be calculated correctly
-        // We fall back to the guardian set size as quorum for < 3, because 2/3+ for <3 is always the set size
-        require((guardian_set.keys.length < 3 && len_signers == guardian_set.keys.length) || (len_signers >= 3 && ((guardian_set.keys.length / 3) * 2) + 1 <= len_signers), "no quorum");
+        // We're using a fixed point number transformation with 1 decimal to deal with rounding.
+        require(((guardian_set.keys.length * 10 / 3) * 2) / 10 + 1 <= len_signers, "no quorum");
 
         int16 last_index = - 1;
         for (uint i = 0; i < len_signers; i++) {

--- a/solana/bridge/src/processor.rs
+++ b/solana/bridge/src/processor.rs
@@ -627,12 +627,9 @@ impl Bridge {
             .filter(|v| v.iter().filter(|v| **v != 0).count() != 0)
             .count() as u8);
         // Check quorum
-        // For guardian sets  < 3, the division by 3 evaluates to 0 and the quorum would not be calculated correctly
-        // We fall back to the guardian set size as quorum for < 3, because 2/3+ for <3 is always the set size
-        if (guardian_set.len_keys < 3 && signature_count != guardian_set.len_keys)
-            || (guardian_set.len_keys >= 3
-                && signature_count < (((guardian_set.len_keys / 3) * 2) + 1))
-        {
+        // We're using a fixed point number transformation with 1 decimal to deal with rounding.
+        // The cast to u16 exists to prevent issues where len_keys * 10 might overflow.
+        if (signature_count as u16) < ((((guardian_set.len_keys as u16) * 10 / 3) * 2) / 10 + 1) {
             return Err(ProgramError::InvalidArgument);
         }
 


### PR DESCRIPTION
Previously we had rounding errors due to the usage of integers for calculating `n * 2/3`.

This was fixed by using one decimal fix point numbers during this part of the calucation.

Overflows were mitigated using a u16 cast on Rust. No mitigations are needed in Solidity since `.length` is a u256 (https://solidity.readthedocs.io/en/v0.5.3/types.html#array-members)