### PR TITLE
bridge: refactor out devnetVAASubmission in observation.go

### DIFF
--- a/bridge/pkg/processor/quorum.go
+++ b/bridge/pkg/processor/quorum.go
@@ -1,6 +1,6 @@
 package processor
 
-// CalculateQuorum returns the minimum number of have that needs to sign a VAA for a given guardian set.
+// CalculateQuorum returns the minimum number of guardians that need to sign a VAA for a given guardian set.
 //
 // The canonical source is the calculation in the contracts (solana/bridge/src/processor.rs and
 // ethereum/contracts/Wormhole.sol), and this needs to match the implementation in the contracts.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72 bridge: implement aggregation timeouts and retransmissions
* **#71 bridge: refactor out devnetVAASubmission in observation.go**
* #70 bridge: split up processor.go

Summary: