### PR TITLE
bridge: implement bridge key serialization

### DIFF
--- a/bridge/cmd/guardiand/bridgekey.go
+++ b/bridge/cmd/guardiand/bridgekey.go
@@ -1,0 +1,66 @@
+package guardiand
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io/ioutil"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	"github.com/certusone/wormhole/bridge/pkg/devnet"
+	nodev1 "github.com/certusone/wormhole/bridge/pkg/proto/node/v1"
+)
+
+// loadGuardianKey loads a serialized guardian key from disk.
+func loadGuardianKey(filename string) (*ecdsa.PrivateKey, error) {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read guardian private key from disk: %w", err)
+	}
+
+	var m nodev1.GuardianKey
+	err = prototext.Unmarshal(b, &m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize private key from disk: %w", err)
+	}
+
+	gk, err := ethcrypto.ToECDSA(m.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize key data: %w", err)
+	}
+
+	return gk, nil
+}
+
+// writeGuardianKey serializes a guardian key and writes it to disk.
+func writeGuardianKey(key *ecdsa.PrivateKey, description string, filename string) error {
+	m := &nodev1.GuardianKey{
+		Description: description,
+		Data:        ethcrypto.FromECDSA(key),
+		Pubkey:      ethcrypto.PubkeyToAddress(key.PublicKey).String(),
+	}
+
+	b, err := prototext.MarshalOptions{Multiline: true, EmitASCII: true}.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := ioutil.WriteFile(filename, b, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateDevnetGuardianKey returns a deterministic testnet key.
+func generateDevnetGuardianKey() (*ecdsa.PrivateKey, error) {
+	// Figure out our devnet index
+	idx, err := devnet.GetDevnetIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate guardian key
+	return devnet.DeterministicEcdsaKeyByIndex(ethcrypto.S256(), uint64(idx)), nil
+}

--- a/bridge/cmd/guardiand/nodekey.go
+++ b/bridge/cmd/guardiand/nodekey.go
@@ -1,39 +1,13 @@
 package guardiand
 
 import (
-	"crypto/ecdsa"
 	"fmt"
 	"io/ioutil"
 	"os"
 
-	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"go.uber.org/zap"
-
-	"github.com/certusone/wormhole/bridge/pkg/devnet"
 )
-
-func loadGuardianKey(logger *zap.Logger) *ecdsa.PrivateKey {
-	var gk *ecdsa.PrivateKey
-
-	if *unsafeDevMode {
-		// Figure out our devnet index
-		idx, err := devnet.GetDevnetIndex()
-		if err != nil {
-			logger.Fatal("Failed to parse hostname - are we running in devnet?")
-		}
-
-		// Generate guardian key
-		gk = devnet.DeterministicEcdsaKeyByIndex(ethcrypto.S256(), uint64(idx))
-	} else {
-		panic("not implemented") // TODO
-	}
-
-	logger.Info("Loaded guardian key", zap.String(
-		"address", ethcrypto.PubkeyToAddress(gk.PublicKey).String()))
-
-	return gk
-}
 
 func getOrCreateNodeKey(logger *zap.Logger, path string) (p2pcrypto.PrivKey, error) {
 	b, err := ioutil.ReadFile(path)

--- a/devnet/bridge.yaml
+++ b/devnet/bridge.yaml
@@ -76,6 +76,8 @@ spec:
             - --ethConfirmations
             - '3'
             - --unsafeDevMode
+            - --bridgeKey
+            - /tmp/bridge.key
 #            - --logLevel=debug
           securityContext:
             capabilities:

--- a/proto/node/v1/node.proto
+++ b/proto/node/v1/node.proto
@@ -6,4 +6,16 @@ option go_package = "proto/node/v1;nodev1";
 
 import "google/api/annotations.proto";
 
-service Node {}
+service Node {
+}
+
+message GuardianKey {
+    // description is an optional, free-form description text set by the operator.
+    string description = 1;
+
+    // data is the binary representation of the secp256k1 private key.
+    bytes data = 2;
+
+    // pubkey is a human-readable representation of the key, included for operator convenience.
+    string pubkey = 3;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* #104 bridge: implement guardian set update submission node admin service
* #103 terra: disable in production mode
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* **#90 bridge: implement bridge key serialization**
* #89 ethereum: update packages and use package-lock.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/90)
<!-- Reviewable:end -->
