### PR TITLE
solana: verify that new guardian set isn't empty

### DIFF
--- a/solana/bridge/src/processor.rs
+++ b/solana/bridge/src/processor.rs
@@ -735,6 +735,10 @@ impl Bridge {
             return Err(Error::AlreadyExists.into());
         }
 
+        if b.new_keys.len() == 0 {
+            return Err(Error::InvalidVAAFormat.into());
+        }
+
         if b.new_keys.len() > MAX_LEN_GUARDIAN_KEYS {
             return Err(Error::InvalidVAAFormat.into());
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* #104 bridge: implement guardian set update submission node admin service
* #103 terra: disable in production mode
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* **#101 solana: verify that new guardian set isn't empty**
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/101)
<!-- Reviewable:end -->
