### PR TITLE
bridge: refactor out broadcastSignature to prepare for injection path

### DIFF
--- a/bridge/pkg/processor/broadcast.go
+++ b/bridge/pkg/processor/broadcast.go
@@ -1,0 +1,51 @@
+package processor
+
+import (
+	"encoding/hex"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"google.golang.org/protobuf/proto"
+
+	gossipv1 "github.com/certusone/wormhole/bridge/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/bridge/pkg/vaa"
+)
+
+func (p *Processor) broadcastSignature(v *vaa.VAA, signature []byte) {
+	digest, err := v.SigningMsg()
+	if err != nil {
+		panic(err)
+	}
+
+	obsv := gossipv1.LockupObservation{
+		Addr:      crypto.PubkeyToAddress(p.gk.PublicKey).Bytes(),
+		Hash:      digest.Bytes(),
+		Signature: signature,
+	}
+
+	w := gossipv1.GossipMessage{Message: &gossipv1.GossipMessage_LockupObservation{LockupObservation: &obsv}}
+
+	msg, err := proto.Marshal(&w)
+	if err != nil {
+		panic(err)
+	}
+
+	p.sendC <- msg
+
+	// Store our VAA in case we're going to submit it to Solana
+	hash := hex.EncodeToString(digest.Bytes())
+
+	if p.state.vaaSignatures[hash] == nil {
+		p.state.vaaSignatures[hash] = &vaaState{
+			firstObserved: time.Now(),
+			signatures:    map[ethcommon.Address][]byte{},
+		}
+	}
+
+	p.state.vaaSignatures[hash].ourVAA = v
+	p.state.vaaSignatures[hash].ourMsg = msg
+
+	// Fast path for our own signature
+	go func() { p.obsvC <- &obsv }()
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* #104 bridge: implement guardian set update submission node admin service
* #103 terra: disable in production mode
* **#102 bridge: refactor out broadcastSignature to prepare for injection path**
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/102)
<!-- Reviewable:end -->
