### PR TITLE
terra: disable in production mode

### DIFF
--- a/bridge/cmd/guardiand/bridge.go
+++ b/bridge/cmd/guardiand/bridge.go
@@ -209,6 +209,10 @@ func runBridge(cmd *cobra.Command, args []string) {
 		logger.Fatal("Please specify -nodeName")
 	}
 	if *terraSupport {
+		if !*unsafeDevMode {
+			logger.Fatal("cannot enable terra support in production mode")
+		}
+
 		if *terraWS == "" {
 			logger.Fatal("Please specify -terraWS")
 		}

--- a/bridge/pkg/processor/observation.go
+++ b/bridge/pkg/processor/observation.go
@@ -199,8 +199,20 @@ func (p *Processor) devnetVAASubmission(ctx context.Context, signed *vaa.VAA, ha
 	}
 }
 
-// Submit VAA to Terra devnet.
+// Submit VAA to Terra.
 func (p *Processor) terraVAASubmission(ctx context.Context, signed *vaa.VAA, hash string) {
+	// Terra support is not yet ready for production.
+	//  - https://github.com/certusone/wormhole/issues/83
+	//  - https://github.com/certusone/wormhole/issues/95
+	//  - https://github.com/certusone/wormhole/issues/97
+	//
+	// Roadmap: https://github.com/certusone/wormhole/milestone/4
+	if !p.devnetMode || p.terraChaidID == "" {
+		p.logger.Warn("ignoring terra VAA submission",
+			zap.String("digest", hash))
+		return
+	}
+
 	tx, err := terra.SubmitVAA(ctx, p.terraLCD, p.terraChaidID, p.terraContract, p.terraFeePayer, signed)
 	if err != nil {
 		if strings.Contains(err.Error(), "VaaAlreadyExecuted") {

--- a/devnet/bridge.yaml
+++ b/devnet/bridge.yaml
@@ -60,17 +60,17 @@ spec:
             - bridge
             - --ethRPC
             - ws://eth-devnet:8545
-            - --terra
-            - --terraWS
-            - ws://terra-terrad:26657/websocket
-            - --terraLCD
-            - http://terra-lcd:1317
-            - --terraChainID
-            - localterra
-            - --terraContract
-            - terra174kgn5rtw4kf6f938wm7kwh70h2v4vcfd26jlc
-            - --terraFeePayer
-            - $(TERRA_FEE_PAYER)
+#            - --terra
+#            - --terraWS
+#            - ws://terra-terrad:26657/websocket
+#            - --terraLCD
+#            - http://terra-lcd:1317
+#            - --terraChainID
+#            - localterra
+#            - --terraContract
+#            - terra174kgn5rtw4kf6f938wm7kwh70h2v4vcfd26jlc
+#            - --terraFeePayer
+#            - $(TERRA_FEE_PAYER)
             - --agentRPC
             - localhost:9000
             - --ethConfirmations
@@ -78,6 +78,8 @@ spec:
             - --unsafeDevMode
             - --bridgeKey
             - /tmp/bridge.key
+            - --adminSocket
+            - /tmp/admin.sock
 #            - --logLevel=debug
           securityContext:
             capabilities:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* #104 bridge: implement guardian set update submission node admin service
* **#103 terra: disable in production mode**
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/103)
<!-- Reviewable:end -->
