### PR TITLE
bridge: implement guardian set update submission node admin service

### DIFF
--- a/bridge/cmd/guardiand/adminclient.go
+++ b/bridge/cmd/guardiand/adminclient.go
@@ -1,0 +1,87 @@
+package guardiand
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/status-im/keycard-go/hexutils"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	nodev1 "github.com/certusone/wormhole/bridge/pkg/proto/node/v1"
+)
+
+var clientSocketPath *string
+
+func init() {
+	pf := AdminClientInjectGuardianSetUpdateCmd.Flags()
+	clientSocketPath = pf.String("socket", "", "gRPC server path to connect to (usually unix:///path/to.sock)")
+	err := cobra.MarkFlagRequired(pf, "socket")
+	if err != nil {
+		panic(err)
+	}
+
+	AdminCmd.AddCommand(AdminClientInjectGuardianSetUpdateCmd)
+	AdminCmd.AddCommand(AdminClientGuardianSetTemplateCmd)
+	AdminCmd.AddCommand(AdminClientGuardianSetVerifyCmd)
+}
+
+var AdminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "Guardian node admin commands",
+}
+
+var AdminClientInjectGuardianSetUpdateCmd = &cobra.Command{
+	Use:   "guardian-set-update-inject",
+	Short: "Inject and sign a guardian set update from a prototxt file (see docs!)",
+	Run:   runInjectGuardianSetUpdate,
+	Args:  cobra.ExactArgs(1),
+}
+
+func getAdminClient(ctx context.Context, addr string) (*grpc.ClientConn, error, nodev1.NodePrivilegedClient) {
+	conn, err := grpc.DialContext(ctx,
+		fmt.Sprintf("passthrough:///%s", addr),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return new(net.Dialer).DialContext(ctx, "unix", addr)
+		}))
+
+	if err != nil {
+		log.Fatalf("failed to connect to %s: %v", addr, err)
+	}
+
+	c := nodev1.NewNodePrivilegedClient(conn)
+	return conn, err, c
+}
+
+func runInjectGuardianSetUpdate(cmd *cobra.Command, args []string) {
+	path := args[0]
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err, c := getAdminClient(ctx, *clientSocketPath)
+	defer conn.Close()
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+	}
+
+	var msg nodev1.GuardianSetUpdate
+	err = prototext.Unmarshal(b, &msg)
+	if err != nil {
+		log.Fatalf("failed to deserialize: %v", err)
+	}
+
+	resp, err := c.SubmitGuardianSetVAA(ctx, &nodev1.SubmitGuardianSetVAARequest{GuardianSet: &msg})
+	if err != nil {
+		log.Fatalf("failed to submit guardian set update: %v", err)
+	}
+
+	log.Printf("VAA successfully injected with digest %s", hexutils.BytesToHex(resp.Digest))
+}

--- a/bridge/cmd/guardiand/adminserver.go
+++ b/bridge/cmd/guardiand/adminserver.go
@@ -1,0 +1,123 @@
+package guardiand
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/certusone/wormhole/bridge/pkg/common"
+	nodev1 "github.com/certusone/wormhole/bridge/pkg/proto/node/v1"
+	"github.com/certusone/wormhole/bridge/pkg/supervisor"
+	"github.com/certusone/wormhole/bridge/pkg/vaa"
+)
+
+type nodePrivilegedService struct {
+	nodev1.UnimplementedNodePrivilegedServer
+	injectC chan<- *vaa.VAA
+	logger  *zap.Logger
+}
+
+// adminGuardianSetUpdateToVAA converts a nodev1.GuardianSetUpdate message to its canonical VAA representation.
+// Returns an error if the data is invalid.
+func adminGuardianSetUpdateToVAA(req *nodev1.GuardianSetUpdate) (*vaa.VAA, error) {
+	if len(req.Guardians) == 0 {
+		return nil, errors.New("empty guardian set specified")
+	}
+
+	if len(req.Guardians) > common.MaxGuardianCount {
+		return nil, fmt.Errorf("too many guardians - %d, maximum is %d", len(req.Guardians), common.MaxGuardianCount)
+	}
+
+	addrs := make([]ethcommon.Address, len(req.Guardians))
+	for i, g := range req.Guardians {
+		if !ethcommon.IsHexAddress(g.Pubkey) {
+			return nil, fmt.Errorf("invalid pubkey format at index %d (%s)", i, g.Name)
+		}
+
+		addrs[i] = ethcommon.HexToAddress(g.Pubkey)
+	}
+
+	v := &vaa.VAA{
+		Version:          vaa.SupportedVAAVersion,
+		GuardianSetIndex: req.CurrentSetIndex,
+		Timestamp:        time.Unix(int64(req.Timestamp), 0),
+		Payload: &vaa.BodyGuardianSetUpdate{
+			Keys:     addrs,
+			NewIndex: req.CurrentSetIndex + 1,
+		},
+	}
+
+	return v, nil
+}
+
+func (s *nodePrivilegedService) SubmitGuardianSetVAA(ctx context.Context, req *nodev1.SubmitGuardianSetVAARequest) (*nodev1.SubmitGuardianSetVAAResponse, error) {
+	s.logger.Info("guardian set injected via admin socket", zap.String("request", req.String()))
+
+	v, err := adminGuardianSetUpdateToVAA(req.GuardianSet)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Generate digest of the unsigned VAA.
+	digest, err := v.SigningMsg()
+	if err != nil {
+		panic(err)
+	}
+
+	s.logger.Info("guardian set VAA constructed",
+		zap.Any("vaa", v),
+		zap.String("digest", digest.String()),
+	)
+
+	s.injectC <- v
+
+	return &nodev1.SubmitGuardianSetVAAResponse{Digest: digest.Bytes()}, nil
+}
+
+func adminServiceRunnable(logger *zap.Logger, socketPath string, injectC chan<- *vaa.VAA) (supervisor.Runnable, error) {
+	// Delete existing UNIX socket, if present.
+	fi, err := os.Stat(socketPath)
+	if err == nil {
+		fmode := fi.Mode()
+		if fmode&os.ModeType == os.ModeSocket {
+			err = os.Remove(socketPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove existing socket at %s: %w", socketPath, err)
+			}
+		} else {
+			return nil, fmt.Errorf("%s is not a UNIX socket", socketPath)
+		}
+	}
+
+	// Create a new UNIX socket and listen to it.
+
+	// The socket is created with the default umask. We set a restrictive umask in setRestrictiveUmask
+	// to ensure that any files we create are only readable by the user - this is much harder to mess up.
+	// The umask avoids a race condition between file creation and chmod.
+
+	laddr, err := net.ResolveUnixAddr("unix", socketPath)
+	l, err := net.ListenUnix("unix", laddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", socketPath, err)
+	}
+
+	logger.Info("listening on", zap.String("path", socketPath))
+
+	nodeService := &nodePrivilegedService{
+		injectC: injectC,
+		logger:  logger.Named("adminservice"),
+	}
+
+	grpcServer := grpc.NewServer()
+	nodev1.RegisterNodePrivilegedServer(grpcServer, nodeService)
+	return supervisor.GRPCServer(grpcServer, l, false), nil
+}

--- a/bridge/cmd/guardiand/admintemplate.go
+++ b/bridge/cmd/guardiand/admintemplate.go
@@ -1,0 +1,59 @@
+package guardiand
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	"github.com/certusone/wormhole/bridge/pkg/devnet"
+	nodev1 "github.com/certusone/wormhole/bridge/pkg/proto/node/v1"
+)
+
+var templateNumGuardians *int
+
+func init() {
+	templateNumGuardians = AdminClientGuardianSetTemplateCmd.Flags().Int("num", 1, "Number of devnet guardians in example file")
+}
+
+var AdminClientGuardianSetTemplateCmd = &cobra.Command{
+	Use:   "guardian-set-update-template",
+	Short: "Generate an empty guardian set template at specified path (offline)",
+	Run:   runGuardianSetTemplate,
+	Args:  cobra.ExactArgs(1),
+}
+
+func runGuardianSetTemplate(cmd *cobra.Command, args []string) {
+	path := args[0]
+
+	// Use deterministic devnet addresses as examples in the template, such that this doubles as a test fixture.
+	guardians := make([]*nodev1.GuardianSetUpdate_Guardian, *templateNumGuardians)
+	for i := 0; i < *templateNumGuardians; i++ {
+		k := devnet.DeterministicEcdsaKeyByIndex(crypto.S256(), uint64(i))
+		guardians[i] = &nodev1.GuardianSetUpdate_Guardian{
+			Pubkey: crypto.PubkeyToAddress(k.PublicKey).Hex(),
+			Name:   fmt.Sprintf("Example validator %d", i),
+		}
+	}
+
+	m := &nodev1.GuardianSetUpdate{
+		CurrentSetIndex: 1,
+		// Timestamp is hardcoded to make it reproducible on different devnet nodes.
+		// In production, a real UNIX timestamp should be used (see node.proto).
+		Timestamp: 1605744545,
+		Guardians: guardians,
+	}
+
+	b, err := prototext.MarshalOptions{Multiline: true}.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	err = ioutil.WriteFile(path, b, 0640)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/bridge/cmd/guardiand/adminverify.go
+++ b/bridge/cmd/guardiand/adminverify.go
@@ -1,0 +1,46 @@
+package guardiand
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	nodev1 "github.com/certusone/wormhole/bridge/pkg/proto/node/v1"
+)
+
+var AdminClientGuardianSetVerifyCmd = &cobra.Command{
+	Use:   "guardian-set-update-verify",
+	Short: "Verify guardian set update in prototxt format (offline)",
+	Run:   runGuardianSetVerify,
+	Args:  cobra.ExactArgs(1),
+}
+
+func runGuardianSetVerify(cmd *cobra.Command, args []string) {
+	path := args[0]
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+	}
+
+	var msg nodev1.GuardianSetUpdate
+	err = prototext.Unmarshal(b, &msg)
+	if err != nil {
+		log.Fatalf("failed to deserialize: %v", err)
+	}
+
+	v, err := adminGuardianSetUpdateToVAA(&msg)
+	if err != nil {
+		log.Fatalf("invalid update: %v", err)
+	}
+
+	digest, err := v.SigningMsg()
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("VAA with digest %s: %+v", digest.Hex(), spew.Sdump(v))
+}

--- a/bridge/cmd/guardiand/bridgekey.go
+++ b/bridge/cmd/guardiand/bridgekey.go
@@ -32,6 +32,7 @@ var KeygenCmd = &cobra.Command{
 
 func runKeygen(cmd *cobra.Command, args []string) {
 	lockMemory()
+	setRestrictiveUmask()
 
 	log.Print("Creating new key at ", args[0])
 

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.guardiand.yaml)")
 	rootCmd.AddCommand(guardiand.BridgeCmd)
 	rootCmd.AddCommand(guardiand.KeygenCmd)
+	rootCmd.AddCommand(guardiand.AdminCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20201012165903-2cb20defcd66 // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
 	github.com/cenkalti/backoff/v4 v4.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/ethereum/go-ethereum v1.9.23
@@ -45,7 +46,7 @@ require (
 	github.com/shirou/gopsutil v2.20.9+incompatible // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.6.3
-	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 // indirect
+	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969
 	github.com/stretchr/testify v1.6.1
 	github.com/tendermint/tendermint v0.33.8 // indirect
 	github.com/terra-project/terra.go v1.0.1-0.20201113170042-b3bffdc6fd06

--- a/bridge/pkg/common/guardianset.go
+++ b/bridge/pkg/common/guardianset.go
@@ -4,6 +4,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// TODO: this should be 20, https://github.com/certusone/wormhole/issues/86
+//
+// Matching constants:
+//  - MAX_LEN_GUARDIAN_KEYS in Solana contract
+//
+// The Eth and Terra contracts do not specify a maximum number and support more than 20,
+// but presumably, chain-specific transaction size limits will apply at some point (untested).
+const MaxGuardianCount = 19
+
 type GuardianSet struct {
 	// Guardian's public keys truncated by the ETH standard hashing mechanism (20 bytes).
 	Keys []common.Address

--- a/bridge/pkg/processor/injection.go
+++ b/bridge/pkg/processor/injection.go
@@ -1,0 +1,48 @@
+package processor
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+
+	"github.com/certusone/wormhole/bridge/pkg/supervisor"
+	"github.com/certusone/wormhole/bridge/pkg/vaa"
+)
+
+// handleInjection processes a pre-populated VAA injected locally.
+func (p *Processor) handleInjection(ctx context.Context, v *vaa.VAA) {
+	// Check if we're in the guardian set.
+	us, ok := p.gs.KeyIndex(p.ourAddr)
+	if !ok {
+		p.logger.Error("we're not in the guardian set - refusing to sign",
+			zap.Uint32("index", p.gs.Index),
+			zap.Stringer("our_addr", p.ourAddr),
+			zap.Any("set", p.gs.KeysAsHexStrings()))
+		return
+	}
+
+	// Generate digest of the unsigned VAA.
+	digest, err := v.SigningMsg()
+	if err != nil {
+		panic(err)
+	}
+
+	// The internal originator is responsible for logging the full VAA, just log the digest here.
+	supervisor.Logger(ctx).Info("signing injected VAA",
+		zap.Stringer("digest", digest))
+
+	// Sign the digest using our node's guardian key.
+	s, err := crypto.Sign(digest.Bytes(), p.gk)
+	if err != nil {
+		panic(err)
+	}
+
+	p.logger.Info("observed and signed injected VAA",
+		zap.String("digest", hex.EncodeToString(digest.Bytes())),
+		zap.String("signature", hex.EncodeToString(s)),
+		zap.Int("our_index", us))
+
+	p.broadcastSignature(v, s)
+}

--- a/bridge/pkg/processor/processor.go
+++ b/bridge/pkg/processor/processor.go
@@ -50,6 +50,9 @@ type Processor struct {
 	// vaaC is a channel of VAAs to submit to store on Solana (either as target, or for data availability)
 	vaaC chan *vaa.VAA
 
+	// injectC is a channel of VAAs injected locally.
+	injectC chan *vaa.VAA
+
 	// gk is the node's guardian private key
 	gk *ecdsa.PrivateKey
 
@@ -84,6 +87,7 @@ func NewProcessor(
 	sendC chan []byte,
 	obsvC chan *gossipv1.LockupObservation,
 	vaaC chan *vaa.VAA,
+	injectC chan *vaa.VAA,
 	gk *ecdsa.PrivateKey,
 	devnetMode bool,
 	devnetNumGuardians uint,
@@ -99,6 +103,7 @@ func NewProcessor(
 		sendC:              sendC,
 		obsvC:              obsvC,
 		vaaC:               vaaC,
+		injectC:            injectC,
 		gk:                 gk,
 		devnetMode:         devnetMode,
 		devnetNumGuardians: devnetNumGuardians,
@@ -134,6 +139,8 @@ func (p *Processor) Run(ctx context.Context) error {
 			}
 		case k := <-p.lockC:
 			p.handleLockup(ctx, k)
+		case v := <-p.injectC:
+			p.handleInjection(ctx, v)
 		case m := <-p.obsvC:
 			p.handleObservation(ctx, m)
 		case <-p.cleanup.C:

--- a/proto/gossip/v1/gossip.proto
+++ b/proto/gossip/v1/gossip.proto
@@ -40,6 +40,8 @@ message Heartbeat {
 // guardians submitting valid signatures for a given hash, they can be assembled into a VAA.
 //
 // Messages without valid signature are dropped unceremoniously.
+//
+// TODO: rename? we also use it for governance VAAs
 message LockupObservation {
   // Guardian pubkey as truncated eth address.
   bytes addr = 1;

--- a/proto/node/v1/node.proto
+++ b/proto/node/v1/node.proto
@@ -6,9 +6,58 @@ option go_package = "proto/node/v1;nodev1";
 
 import "google/api/annotations.proto";
 
-service Node {
+// NodePrivileged exposes an administrative API. It runs on a UNIX socket and is authenticated
+// using Linux filesystem permissions.
+service NodePrivileged {
+    // SubmitGuardianSetVAA injects a guardian set change VAA into the guardian node.
+    // The node will inject the VAA into the aggregator and sign/broadcast the VAA signature.
+    //
+    // A consensus majority of nodes on the network will have to inject the VAA within the
+    // VAA timeout window for it to reach consensus.
+    //
+    rpc SubmitGuardianSetVAA (SubmitGuardianSetVAARequest) returns (SubmitGuardianSetVAAResponse);
 }
 
+// GuardianSet represents a new guardian set to be submitted to and signed by the node.
+// During the genesis procedure, this data structure will be assembled using off-chain collaborative tooling
+// like GitHub using a human-readable encoding, so readability is a concern.
+message GuardianSetUpdate {
+    // Index of the current guardian set to be replaced.
+    uint32 current_set_index = 1;
+
+    // UNIX timestamp (s) of the VAA to be created. The timestamp is informational and will be part
+    // of the VAA submitted to the chain. It's part of the VAA digest and has to be identical across nodes.
+    //
+    // For lockups, the timestamp identifies the block that the lockup belongs to. For guardian set updates,
+    // we create the VAA manually. Best practice is to pick a timestamp which roughly matches the expected
+    // genesis ceremony data.
+    //
+    // The actual on-chain guardian set creation timestamp will be set when the VAA is accepted on each chain.
+    //
+    // This is a uint32 to match the on-chain timestamp representation. This becomes a problem in 2106 (sorry).
+    uint32 timestamp = 2;
+
+    // List of guardian set members.
+    message Guardian {
+        // Guardian key pubkey. Stored as hex string with 0x prefix for human readability -
+        // this is the canonical Ethereum representation.
+        string pubkey = 1;
+        // Optional descriptive name. Not stored on any chain, purely informational.
+        string name = 2;
+    };
+    repeated Guardian guardians = 3;
+}
+
+message SubmitGuardianSetVAARequest {
+    GuardianSetUpdate guardian_set = 1;
+}
+
+message SubmitGuardianSetVAAResponse {
+    // Canonical digest of the submitted VAA.
+    bytes digest = 1;
+}
+
+// GuardianKey specifies the on-disk format for a node's guardian key.
 message GuardianKey {
     // description is an optional, free-form description text set by the operator.
     string description = 1;

--- a/scripts/test-injection.sh
+++ b/scripts/test-injection.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script submits a guardian set update using the VAA injection admin command.
+# First argument is node to submit to.
+set -e
+
+node=$1
+path=/tmp/new-guardianset.prototxt
+sock=/tmp/admin.sock
+
+# Create a no-op update that sets the same 1-node guardian set again.
+kubectl exec guardian-${node} -c guardiand -- /guardiand admin guardian-set-update-template --num=1 $path
+
+# Verify and print resulting result. The digest incorporates the current time and is NOT deterministic.
+kubectl exec guardian-${node} -c guardiand -- /guardiand admin guardian-set-update-verify $path
+
+# Submit to node
+kubectl exec guardian-${node} -c guardiand -- /guardiand admin guardian-set-update-inject --socket $sock $path


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* **#104 bridge: implement guardian set update submission node admin service**
* #103 terra: disable in production mode
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

Tested on a live devnet via `scripts/test-injection.sh 0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/104)
<!-- Reviewable:end -->
