### PR TITLE
bridge/pkg/ethereum: remove channel unsubscribes

### DIFF
--- a/bridge/pkg/ethereum/watcher.go
+++ b/bridge/pkg/ethereum/watcher.go
@@ -70,7 +70,6 @@ func (e *EthBridgeWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to token lockup events: %w", err)
 	}
-	defer tokensLockedSub.Unsubscribe()
 
 	// Subscribe to guardian set changes
 	guardianSetC := make(chan *abi.AbiLogGuardianSetChanged, 2)
@@ -78,7 +77,6 @@ func (e *EthBridgeWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to guardian set events: %w", err)
 	}
-	defer tokensLockedSub.Unsubscribe()
 
 	errC := make(chan error)
 	logger := supervisor.Logger(ctx)
@@ -167,7 +165,6 @@ func (e *EthBridgeWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to header events: %w", err)
 	}
-	defer headerSubscription.Unsubscribe()
 
 	go func() {
 		for {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#109 bridge/pkg/ethereum: remove channel unsubscribes**
* #104 bridge: implement guardian set update submission node admin service
* #103 terra: disable in production mode
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

Unsubscribe() does blocking I/O that ignores the runnable context
and can block forever: #107

It would appear that removing the Unsubscribe calls is the only
way to work around this go-ethereum bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/109)
<!-- Reviewable:end -->
