### PR TITLE
solana: fix guardian_set_index update

### DIFF
--- a/solana/bridge/src/processor.rs
+++ b/solana/bridge/src/processor.rs
@@ -582,7 +582,9 @@ impl Bridge {
         let sig_info = next_account_info(account_info_iter)?;
         let payer_info = next_account_info(account_info_iter)?;
 
-        let mut bridge = Bridge::bridge_deserialize(bridge_info)?;
+        let mut bridge_data = bridge_info.try_borrow_mut_data()?;
+        let mut bridge = Bridge::unpack(&mut bridge_data)?;
+
         let clock = Clock::from_account_info(clock_info)?;
         let mut guardian_set = Bridge::guardian_set_deserialize(guardian_set_info)?;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#112 solana: fix guardian_set_index update**
* #109 bridge/pkg/ethereum: remove channel unsubscribes
* #104 bridge: implement guardian set update submission node admin service
* #103 terra: disable in production mode
* #102 bridge: refactor out broadcastSignature to prepare for injection path
* #101 solana: verify that new guardian set isn't empty
* #92 docs: add simple overview image
* #91 bridge: implement keygen command
* #90 bridge: implement bridge key serialization
* #89 ethereum: update packages and use package-lock.json

Fixes #110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/112)
<!-- Reviewable:end -->
