### PR TITLE
Don't evict governance VAA signatures

### DIFF
--- a/solana/bridge/src/processor.rs
+++ b/solana/bridge/src/processor.rs
@@ -722,7 +722,6 @@ impl Bridge {
                 let mut bridge_data = bridge_info.try_borrow_mut_data()?;
                 let bridge: &mut Bridge = Self::unpack(&mut bridge_data)?;
 
-                evict_signatures = true;
                 Self::process_vaa_set_update(
                     program_id,
                     accounts,


### PR DESCRIPTION
They need to persist for data availability (to be cross-submitted to other chains).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/137)
<!-- Reviewable:end -->
