### PR TITLE
Fix guardian set expiration on Solana

### DIFF
--- a/solana/bridge/src/processor.rs
+++ b/solana/bridge/src/processor.rs
@@ -699,7 +699,7 @@ impl Bridge {
         }
 
         // Check that the guardian set is still active
-        if (guardian_set.expiration_time as i64) > clock.unix_timestamp {
+        if guardian_set.expiration_time != 0 && (guardian_set.expiration_time as i64) < clock.unix_timestamp {
             return Err(Error::GuardianSetExpired.into());
         }
 
@@ -885,6 +885,8 @@ impl Bridge {
 
         // Set values on the new guardian set
         guardian_set_new.is_initialized = true;
+        // Force the new guardian set to not expire
+        guardian_set_new.expiration_time = 0;
         guardian_set_new.index = b.new_index;
         let mut new_guardians = [[0u8; 20]; MAX_LEN_GUARDIAN_KEYS];
         for n in 0..b.new_keys.len() {


### PR DESCRIPTION
The expiration set is set to the time when the set was changed + expiration constant. So the guardian set is expired when that time is in the past.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/155)
<!-- Reviewable:end -->
