### PR TITLE
Use /usr/bin/env for shell scripts; web/.dockerignore: node_modules

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 #
 # This script downloads and installs development dependencies required for

--- a/ethereum/copy-from-container.sh
+++ b/ethereum/copy-from-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script copies package{-lock}.json from a running container.
 set -e
 

--- a/generate-abi.sh
+++ b/generate-abi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regenerate bridge/pkg/ethereum/abi using a running eth-devnet's state.
 set -euo pipefail
 

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 (
   cd tools/

--- a/scripts/send-eth-lockups.sh
+++ b/scripts/send-eth-lockups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 kubectl exec -it -c tests eth-devnet-0 -- npx truffle exec src/send-lockups.js

--- a/scripts/send-solana-lockups.sh
+++ b/scripts/send-solana-lockups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 kubectl exec -it solana-devnet-0 -c setup ./lockups.sh

--- a/scripts/tail.sh
+++ b/scripts/tail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while : ; do
   kubectl logs --tail=1000 --follow=true $1 guardiand

--- a/scripts/test-injection.sh
+++ b/scripts/test-injection.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script submits a guardian set update using the VAA injection admin command.
 # First argument is node to submit to. Second argument is current set index.
 set -e

--- a/solana/devnet_setup.sh
+++ b/solana/devnet_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script configures the devnet for test transfers with hardcoded addresses.
 set -x
 

--- a/solana/lockups.sh
+++ b/solana/lockups.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate test lockups on Solana to be executed on Ethereum
 
 # Constants (hardcoded)

--- a/tilt_modules/namespace/test/test.sh
+++ b/tilt_modules/namespace/test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 go build -mod=readonly -o bin/protoc-gen-go google.golang.org/protobuf/cmd/protoc-gen-go

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
# `#!/usr/bin/env bash`
Hi, I've been trying to run the project according to `DEVELOP.md` on NixOS. I
managed to get most things to work, but Tilt had trouble executing
some of the jobs because of `/bin/bash` being used. NixOS will do the right
thing for `#!/usr/bin/env bash` and `#!/bin/sh` shell scripts but not direct
interpreter paths. Take it with a grain of salt, I replaced that with a "find
and replace in project" tool.

# `web/.dockerignore`
I saw that the web interface container tried to copy the context including
node_modules. I added it to an ignorefile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/159)
<!-- Reviewable:end -->
