### PR TITLE
Fix *.so copy in solana-devnet, correct crate feature for cli+agent

### DIFF
--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -24,4 +24,4 @@ RUN --mount=type=cache,target=/usr/local,from=rust,source=/usr/local \
     --mount=type=cache,target=bin,from=rust,source=bin \
     cargo build-bpf --manifest-path "bridge/Cargo.toml" && \
     mkdir -p /opt/solana/deps && \
-    cp target/deploy/spl_bridge_debug.so /opt/solana/deps/spl_bridge.so
+    cp target/deploy/spl_bridge.so /opt/solana/deps/spl_bridge.so

--- a/solana/agent/Cargo.toml
+++ b/solana/agent/Cargo.toml
@@ -12,8 +12,8 @@ prost-types = "0.6"
 solana-sdk = { version = "=1.5.5" }
 solana-client = { version = "=1.5.5" }
 solana-faucet = "=1.5.5"
-spl-token =  "=3.0.1"
-wormhole-bridge = { path = "../bridge" }
+spl-token = {version = "=3.0.1", features = ["no-entrypoint"]}
+wormhole-bridge = { path = "../bridge", default-features = false, features = ["no-entrypoint"] }
 primitive-types = { version = "0.7.2" }
 hex = "0.4.2"
 thiserror = "1.0.20"

--- a/solana/cli/Cargo.toml
+++ b/solana/cli/Cargo.toml
@@ -15,8 +15,8 @@ solana-sdk = { version = "=1.5.5" }
 solana-client = { version = "=1.5.5" }
 solana-faucet = "=1.5.5"
 solana-account-decoder = { version = "=1.5.5" }
-spl-token = "=3.0.1"
-wormhole-bridge = { path = "../bridge" }
+spl-token = {version = "=3.0.1", features = ["no-entrypoint"]}
+wormhole-bridge = { path = "../bridge", default-features = false, features = ["no-entrypoint"] }
 primitive-types = { version = "0.7.2" }
 hex = "0.4.2"
 thiserror = "1.0.20"


### PR DESCRIPTION
Removing do.sh mostly works but seems we had an oopsie or two. 

Testing strategy:  E2E passes on a clean build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/198)
<!-- Reviewable:end -->
