### PR TITLE
Bump Solana toolchain to v1.8.5 (current mainnet release)

### DIFF
--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     rustup component add rustfmt && \
     rustup default nightly-2021-08-01
 
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.8.5/install)"
 
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 


### PR DESCRIPTION
**Stack**:
- #581 ⮜
- #580
- #579
- #578
- #577
- #576




⚠️ *Please do not manually merge this stack, instead, wait for the author to merge it. Manual merging will have unexpected results.*