### PR TITLE
node/pkg/vaa: remove error return value from SigningMsg

### DIFF
--- a/node/cmd/guardiand/adminserver.go
+++ b/node/cmd/guardiand/adminserver.go
@@ -179,7 +179,7 @@ func (s *nodePrivilegedService) InjectGovernanceVAA(ctx context.Context, req *no
 		}
 
 		// Generate digest of the unsigned VAA.
-		digest, err := v.SigningMsg()
+		digest := v.SigningMsg()
 		if err != nil {
 			panic(err)
 		}

--- a/node/cmd/guardiand/adminverify.go
+++ b/node/cmd/guardiand/adminverify.go
@@ -54,7 +54,7 @@ func runGovernanceVAAVerify(cmd *cobra.Command, args []string) {
 			log.Fatalf("invalid update: %v", err)
 		}
 
-		digest, err := v.SigningMsg()
+		digest := v.SigningMsg()
 		if err != nil {
 			panic(err)
 		}

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -23,10 +23,7 @@ var (
 )
 
 func (p *Processor) broadcastSignature(v *vaa.VAA, signature []byte, txhash []byte) {
-	digest, err := v.SigningMsg()
-	if err != nil {
-		panic(err)
-	}
+	digest := v.SigningMsg()
 
 	obsv := gossipv1.SignedObservation{
 		Addr:      crypto.PubkeyToAddress(p.gk.PublicKey).Bytes(),

--- a/node/pkg/processor/injection.go
+++ b/node/pkg/processor/injection.go
@@ -24,10 +24,7 @@ var (
 // handleInjection processes a pre-populated VAA injected locally.
 func (p *Processor) handleInjection(ctx context.Context, v *vaa.VAA) {
 	// Generate digest of the unsigned VAA.
-	digest, err := v.SigningMsg()
-	if err != nil {
-		panic(err)
-	}
+	digest := v.SigningMsg()
 
 	// The internal originator is responsible for logging the full VAA, just log the digest here.
 	supervisor.Logger(ctx).Info("signing injected VAA",

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -118,10 +118,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	}
 
 	// Generate digest of the unsigned VAA.
-	digest, err := v.SigningMsg()
-	if err != nil {
-		panic(err)
-	}
+	digest := v.SigningMsg()
 
 	// Sign the digest using our node's guardian key.
 	s, err := crypto.Sign(digest.Bytes(), p.gk)

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -258,7 +258,7 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 	}
 
 	// Calculate digest for logging
-	digest, err := v.SigningMsg()
+	digest := v.SigningMsg()
 	if err != nil {
 		panic(err)
 	}

--- a/node/pkg/vaa/structs.go
+++ b/node/pkg/vaa/structs.go
@@ -228,22 +228,16 @@ func Unmarshal(data []byte) (*VAA, error) {
 }
 
 // signingBody returns the binary representation of the data that is relevant for signing and verifying the VAA
-func (v *VAA) signingBody() ([]byte, error) {
+func (v *VAA) signingBody() []byte {
 	return v.serializeBody()
 }
 
 // SigningMsg returns the hash of the signing body. This is used for signature generation and verification
-func (v *VAA) SigningMsg() (common.Hash, error) {
-	body, err := v.signingBody()
-	if err != nil {
-		// Should never happen on a successfully parsed VAA
-		return common.Hash{}, fmt.Errorf("failed to serialize signing body: %w", err)
-	}
-
+func (v *VAA) SigningMsg() common.Hash {
 	// In order to save space in the solana signature verification instruction, we hash twice so we only need to pass in
 	// the first hash (32 bytes) vs the full body data.
-	hash := crypto.Keccak256Hash(crypto.Keccak256Hash(body).Bytes())
-	return hash, nil
+	hash := crypto.Keccak256Hash(crypto.Keccak256Hash(v.signingBody()).Bytes())
+	return hash
 }
 
 // VerifySignatures verifies the signature of the VAA given the signer addresses.
@@ -253,10 +247,7 @@ func (v *VAA) VerifySignatures(addresses []common.Address) bool {
 		return false
 	}
 
-	h, err := v.SigningMsg()
-	if err != nil {
-		return false
-	}
+	h := v.SigningMsg()
 
 	for _, sig := range v.Signatures {
 		if int(sig.Index) >= len(addresses) {
@@ -291,11 +282,7 @@ func (v *VAA) Marshal() ([]byte, error) {
 	}
 
 	// Write Body
-	body, err := v.serializeBody()
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize body: %w", err)
-	}
-	buf.Write(body)
+	buf.Write(v.serializeBody())
 
 	return buf.Bytes(), nil
 }
@@ -307,14 +294,10 @@ func (v *VAA) MessageID() string {
 
 // HexDigest returns the hex-encoded digest.
 func (v *VAA) HexDigest() string {
-	b, err := v.SigningMsg()
-	if err != nil {
-		panic(err)
-	}
-	return hex.EncodeToString(b.Bytes())
+	return hex.EncodeToString(v.SigningMsg().Bytes())
 }
 
-func (v *VAA) serializeBody() ([]byte, error) {
+func (v *VAA) serializeBody() []byte {
 	buf := new(bytes.Buffer)
 	MustWrite(buf, binary.BigEndian, uint32(v.Timestamp.Unix()))
 	MustWrite(buf, binary.BigEndian, v.Nonce)
@@ -324,15 +307,11 @@ func (v *VAA) serializeBody() ([]byte, error) {
 	MustWrite(buf, binary.BigEndian, v.ConsistencyLevel)
 	buf.Write(v.Payload)
 
-	return buf.Bytes(), nil
+	return buf.Bytes()
 }
 
 func (v *VAA) AddSignature(key *ecdsa.PrivateKey, index uint8) {
-	data, err := v.SigningMsg()
-	if err != nil {
-		panic(err)
-	}
-	sig, err := crypto.Sign(data.Bytes(), key)
+	sig, err := crypto.Sign(v.SigningMsg().Bytes(), key)
 	if err != nil {
 		panic(err)
 	}

--- a/node/pkg/vaa/types_test.go
+++ b/node/pkg/vaa/types_test.go
@@ -65,8 +65,7 @@ func TestVerifySignature(t *testing.T) {
 		Payload:          []byte("abcd"),
 	}
 
-	data, err := v.SigningMsg()
-	require.NoError(t, err)
+	data := v.SigningMsg()
 
 	key, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	require.NoError(t, err)


### PR DESCRIPTION
**Stack**:
- #641
- #640
- #635
- #634
- #639
- #638
- #637
- #636
- #633 ⮜


<pre>
serializeBody always returns a nil error.
Remove the error return value.
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*