### PR TITLE
node/pkg/vaa: fix TestBodyRegisterChain_Serialize

### DIFF
--- a/node/pkg/vaa/types_test.go
+++ b/node/pkg/vaa/types_test.go
@@ -86,18 +86,13 @@ func TestVerifySignature(t *testing.T) {
 }
 
 func TestBodyRegisterChain_Serialize(t *testing.T) {
-	header, _ := hex.DecodeString("000000000000000000000000000000000000000000546f6b656e427269646765")
-	require.Len(t, header, 32)
-
-	var headerB [32]byte
-	copy(headerB[:], header)
 	msg := &BodyTokenBridgeRegisterChain{
 		ChainID:        8,
 		EmitterAddress: Address{1, 2, 3, 4},
 	}
 
 	data := msg.Serialize()
-	require.Equal(t, "000000000000000000000000000000000000000000546f6b656e42726964676501000000080102030400000000000000000000000000000000000000000000000000000000", hex.EncodeToString(data))
+	require.Equal(t, "000000000000000000000000000000000000000000000000000000000000000001000000080102030400000000000000000000000000000000000000000000000000000000", hex.EncodeToString(data))
 }
 
 func TestBodyRegisterChain_Serializee(t *testing.T) {


### PR DESCRIPTION
**Stack**:
- #635
- #634
- #633


<pre>
I accidentally broke this in 2022b55fd, which removed the header.
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*