### PR TITLE
node/pkg/solana: double number of max retries

### DIFF
--- a/node/pkg/solana/client.go
+++ b/node/pkg/solana/client.go
@@ -62,7 +62,7 @@ var (
 const rpcTimeout = time.Second * 5
 
 // Maximum retries for Solana fetching
-const maxRetries = 5
+const maxRetries = 10
 const retryDelay = 5 * time.Second
 
 type ConsistencyLevel uint8


### PR DESCRIPTION
**Stack**:
- #655
- #649
- #648 ⮜


<pre>
This should reduce the number of misses during periods of heavy weather
and high winds, at the expense of increasing load on the RPC nodes.
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*