### PR TITLE
node/pkg/ethereum: check for rpc.ErrNoResult with non-nil tx

### DIFF
--- a/node/pkg/ethereum/watcher.go
+++ b/node/pkg/ethereum/watcher.go
@@ -312,7 +312,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 								zap.Error(err))
 							continue
 						}
-						if tx == nil {
+						if tx == nil || err == rpc.ErrNoResult {
 							logger.Info("tx was orphaned",
 								zap.Stringer("tx", pLock.message.TxHash),
 								zap.Stringer("blockhash", key.BlockHash),


### PR DESCRIPTION
<pre>
This cannot currently happen the way TransactionReceipt is implemented,
but make sure to check the tx != nil case anyway in case the API
is changed in future releases of go-ethereum.
</pre>
