### PR TITLE
node/pkg/ethereum: reduce timeout for TransactionReceipt

### DIFF
--- a/node/pkg/ethereum/watcher.go
+++ b/node/pkg/ethereum/watcher.go
@@ -313,7 +313,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 					// Transaction is now ready
 					if pLock.height+uint64(expectedConfirmations) <= blockNumberU {
-						timeout, cancel = context.WithTimeout(ctx, 15*time.Second)
+						timeout, cancel = context.WithTimeout(ctx, 5*time.Second)
 						tx, err := c.TransactionReceipt(timeout, pLock.message.TxHash)
 						cancel()
 


### PR DESCRIPTION
**Stack**:
- #743
- #742
- #741
- #740
- #739 ⮜
- #738
- #737
- #736
- #729
- #728
- #727


<pre>
We should spend as little time holding pendingMu as possible.
Ideally, we would refactor the component to do non-blocking I/O.
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*