### PR TITLE
terra/token_bridge: fix cw20 migrations

### DIFF
--- a/terra/contracts/token-bridge/src/contract.rs
+++ b/terra/contracts/token-bridge/src/contract.rs
@@ -122,7 +122,13 @@ const WRAPPED_ASSET_UPDATING: &str = "updating";
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
-    let bucket = wrapped_asset_address(deps.storage);
+    let mut bucket = wrapped_asset_address(deps.storage);
+
+    // Remove registered asset with old code ID.
+    let asset_id = deps.api.addr_canonicalize("terra16q5pke2vueu23y8punvj70h0cp0s0rc7vrzl57")?;
+    bucket.remove(&asset_id);
+    assert!(bucket.load(&asset_id).is_err());
+
     let mut messages = vec![];
     for item in bucket.range(None, None, Order::Ascending) {
         let contract_address = item?.0;


### PR DESCRIPTION
We remove [terra16q5pke2vueu23y8punvj70h0cp0s0rc7vrzl57](https://finder.terra.money/mainnet/address/terra16q5pke2vueu23y8punvj70h0cp0s0rc7vrzl57) from `wrapped_asset_address` because it has no admin. This was already removed from `wrapped_asset` here:
https://github.com/certusone/wormhole/commit/e2a16b67#diff-4d1ad320d9f5ab48ff71ac9974eb9a9b10739c15e740a137d85f4fd0354e98f5R111-R123

(they match up, the asset_address `BpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAE==` in the terra contract decodes to `0x069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001` )