### PR TITLE
p2w-attest: price batching

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-eval "$(lorri direnv)"

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -24,6 +24,6 @@ RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
 # Amusingly, Debian's coreutils version has a bug where mv believes that
 # the target is on a different fs and does a full recursive copy for what
 # could be a renameat syscall. Alpine does not have this bug.
-RUN rmdir node_modules && mv node_modules_cache node_modules
+RUN rm -rf node_modules && mv node_modules_cache node_modules
 
 ADD --chown=node:node . .

--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -1785,6 +1785,8 @@ dependencies = [
  "env_logger 0.8.4",
  "log",
  "pyth2wormhole",
+ "serde",
+ "serde_yaml",
  "shellexpand",
  "solana-client",
  "solana-program",

--- a/solana/pyth2wormhole/client/Cargo.toml
+++ b/solana/pyth2wormhole/client/Cargo.toml
@@ -15,6 +15,8 @@ env_logger = "0.8.4"
 log = "0.4.14"
 wormhole-bridge-solana = {path = "../../bridge/program"}
 pyth2wormhole = {path = "../program"}
+serde = "1"
+serde_yaml = "0.8"
 shellexpand = "2.1.0"
 solana-client = "=1.9.4"
 solana-program = "=1.9.4"

--- a/solana/pyth2wormhole/client/src/attestation_cfg.rs
+++ b/solana/pyth2wormhole/client/src/attestation_cfg.rs
@@ -1,0 +1,84 @@
+use std::str::FromStr;
+
+use serde::{
+    de::Error,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
+use solana_program::pubkey::Pubkey;
+use solitaire::ErrBox;
+
+/// Pyth2wormhole config specific to attestation requests
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AttestationConfig {
+    pub symbols: Vec<P2WSymbol>,
+}
+
+/// Config entry for a Pyth product + price pair
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct P2WSymbol {
+    /// User-defined human-readable name
+    pub name: Option<String>,
+
+    #[serde(
+        deserialize_with = "pubkey_string_de",
+        serialize_with = "pubkey_string_ser"
+    )]
+    pub product_addr: Pubkey,
+    #[serde(
+        deserialize_with = "pubkey_string_de",
+        serialize_with = "pubkey_string_ser"
+    )]
+    pub price_addr: Pubkey,
+}
+
+// Helper methods for strinigified SOL addresses
+
+fn pubkey_string_ser<S>(k: &Pubkey, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    ser.serialize_str(&k.to_string())
+}
+
+fn pubkey_string_de<'de, D>(de: D) -> Result<Pubkey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let pubkey_string = String::deserialize(de)?;
+    let pubkey = Pubkey::from_str(&pubkey_string).map_err(D::Error::custom)?;
+    Ok(pubkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanity() -> Result<(), ErrBox> {
+        let initial = AttestationConfig {
+            symbols: vec![
+                P2WSymbol {
+                    name: Some("ETH/USD".to_owned()),
+                    product_addr: Default::default(),
+                    price_addr: Default::default(),
+                },
+                P2WSymbol {
+                    name: None,
+                    product_addr: Pubkey::new(&[42u8; 32]),
+                    price_addr: Default::default(),
+                },
+            ],
+        };
+
+        let serialized = serde_yaml::to_string(&initial)?;
+        eprintln!("Serialized:\n{}", serialized);
+
+        let deserialized: AttestationConfig = serde_yaml::from_str(&serialized)?;
+
+        assert_eq!(initial, deserialized);
+        Ok(())
+    }
+}

--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -1,6 +1,7 @@
 //! CLI options
 
 use solana_program::pubkey::Pubkey;
+use std::path::PathBuf;
 
 use clap::Clap;
 #[derive(Clap)]
@@ -22,7 +23,7 @@ pub struct Cli {
         default_value = "~/.config/solana/id.json"
     )]
     pub payer: String,
-    #[clap(long, default_value = "http://localhost:8899")]
+    #[clap(short, long, default_value = "http://localhost:8899")]
     pub rpc_url: String,
     #[clap(long)]
     pub p2w_addr: Pubkey,
@@ -35,23 +36,19 @@ pub enum Action {
     #[clap(about = "Initialize a pyth2wormhole program freshly deployed under <p2w_addr>")]
     Init {
 	/// The bridge program account
-	#[clap(long = "wh-prog")]
+	#[clap(short = 'w', long = "wh-prog")]
 	wh_prog: Pubkey,
-	#[clap(long = "owner")]
+	#[clap(short = 'o', long = "owner")]
         owner_addr: Pubkey,
-        #[clap(long = "pyth-owner")]
+        #[clap(short = 'p', long = "pyth-owner")]
         pyth_owner_addr: Pubkey,
     },
     #[clap(
         about = "Use an existing pyth2wormhole program to attest product price information to another chain"
     )]
     Attest {
-        #[clap(long = "product")]
-        product_addr: Pubkey,
-        #[clap(long = "price")]
-        price_addr: Pubkey,
-        #[clap(long)]
-	nonce: u32,
+	#[clap(short = 'f', long = "--config", about = "Attestation YAML config")]
+	attestation_cfg: PathBuf,
     },
     #[clap(about = "Update an existing pyth2wormhole program's settings (currently set owner only)")]
     SetConfig {

--- a/solana/pyth2wormhole/client/src/config_file.rs
+++ b/solana/pyth2wormhole/client/src/config_file.rs
@@ -1,0 +1,34 @@
+#[derive(Deserialize, Serialize)]
+pub struct Config {
+    symbols: Vec<P2WSymbol>,
+}
+
+/// Config entry for a Pyth2Wormhole product + price pair
+#[derive(Deserialize, Serialize)]
+pub struct P2WSymbol {
+    /// User-defined human-readable name
+    name: Option<String>,
+    product: Pubkey,
+    price: Pubkey,
+}
+
+#[testmod]
+mod tests {
+    #[test]
+    fn test_sanity() -> Result<(), ErrBox> {
+        let serialized = r#"
+symbols:
+  - name: ETH/USD
+    product_addr: 11111111111111111111111111111111
+    price_addr: 11111111111111111111111111111111
+  - name: SOL/EUR
+    product_addr: 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi
+    price_addr: 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi
+  - name: BTC/CNY
+    product_addr: 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR
+    price_addr: 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR
+"#;
+        let deserialized = serde_yaml::from_str(serialized)?;
+        Ok(())
+    }
+}

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::P2WConfigAccount,
-    types::PriceAttestation,
+    types::{PriceAttestation, batch_serialize},
 };
 use borsh::{
     BorshDeserialize,
@@ -28,6 +28,7 @@ use bridge::{
 };
 
 use solitaire::{
+    invoke_seeded,
     trace,
     AccountState,
     Derive,
@@ -40,7 +41,6 @@ use solitaire::{
     Peel,
     Result as SoliResult,
     Seeded,
-    invoke_seeded,
     Signer,
     SolitaireError,
     Sysvar,
@@ -49,14 +49,52 @@ use solitaire::{
 
 pub type P2WEmitter<'b> = Derive<Info<'b>, "p2w-emitter">;
 
+/// Important: must be manually maintained until native Solitaire
+/// variable len vector support. The number must correspond to maximum
+/// number of symbols and reflect how many pyth product/price pairs
+/// are expected in the Attest struct below.
+pub const P2W_MAX_BATCH_SIZE: u16 = 5;
+
 #[derive(FromAccounts, ToInstruction)]
 pub struct Attest<'b> {
     // Payer also used for wormhole
     pub payer: Mut<Signer<Info<'b>>>,
     pub system_program: Info<'b>,
     pub config: P2WConfigAccount<'b, { AccountState::Initialized }>,
+
+    // Hardcoded product/price pairs, bypassing Solitaire's variable-length limitations
+    // Any change to the number of accounts must include an appropriate change to P2W_MAX_BATCH_SIZE
     pub pyth_product: Info<'b>,
     pub pyth_price: Info<'b>,
+
+    pub pyth_product2: Option<Info<'b>>,
+    pub pyth_price2: Option<Info<'b>>,
+
+    pub pyth_product3: Option<Info<'b>>,
+    pub pyth_price3: Option<Info<'b>>,
+
+    pub pyth_product4: Option<Info<'b>>,
+    pub pyth_price4: Option<Info<'b>>,
+
+    pub pyth_product5: Option<Info<'b>>,
+    pub pyth_price5: Option<Info<'b>>,
+
+    // Did you read the comment near `pyth_product`?
+    // pub pyth_product6: Option<Info<'b>>,
+    // pub pyth_price6: Option<Info<'b>>,
+
+    // pub pyth_product7: Option<Info<'b>>,
+    // pub pyth_price7: Option<Info<'b>>,
+
+    // pub pyth_product8: Option<Info<'b>>,
+    // pub pyth_price8: Option<Info<'b>>,
+
+    // pub pyth_product9: Option<Info<'b>>,
+    // pub pyth_price9: Option<Info<'b>>,
+
+    // pub pyth_product10: Option<Info<'b>>,
+    // pub pyth_price10: Option<Info<'b>>,
+
     pub clock: Sysvar<'b, Clock>,
 
     // post_message accounts
@@ -85,7 +123,6 @@ pub struct Attest<'b> {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct AttestData {
-    pub nonce: u32,
     pub consistency_level: ConsistencyLevel,
 }
 
@@ -98,16 +135,6 @@ impl<'b> InstructionContext<'b> for Attest<'b> {
 pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> SoliResult<()> {
     accs.config.verify_derivation(ctx.program_id, None)?;
 
-    if accs.config.pyth_owner != *accs.pyth_price.owner
-        || accs.config.pyth_owner != *accs.pyth_product.owner
-    {
-        trace!(&format!(
-            "pyth_owner pubkey mismatch (expected {:?}, got price owner {:?} and product owner {:?}",
-            accs.config.pyth_owner, accs.pyth_price.owner, accs.pyth_product.owner
-        ));
-        return Err(SolitaireError::InvalidOwner(accs.pyth_price.owner.clone()).into());
-    }
-
     if accs.config.wh_prog != *accs.wh_prog.key {
         trace!(&format!(
             "Wormhole program account mismatch (expected {:?}, got {:?})",
@@ -115,19 +142,101 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
         ));
     }
 
-    let price_attestation = PriceAttestation::from_pyth_price_bytes(
-        accs.pyth_price.key.clone(),
-        accs.clock.unix_timestamp,
-        &*accs.pyth_price.try_borrow_data()?,
-    )?;
+    // Make the specified prices iterable
+    let price_pair_opts = [
+        Some(&accs.pyth_product),
+        Some(&accs.pyth_price),
+        accs.pyth_product2.as_ref(),
+        accs.pyth_price2.as_ref(),
+        accs.pyth_product3.as_ref(),
+        accs.pyth_price3.as_ref(),
+        accs.pyth_product4.as_ref(),
+        accs.pyth_price4.as_ref(),
+        accs.pyth_product5.as_ref(),
+        accs.pyth_price5.as_ref(),
 
-    if &price_attestation.product_id != accs.pyth_product.key {
+	// Did you read the comment near `pyth_product`?
+	// accs.pyth_product6.as_ref(),
+        // accs.pyth_price6.as_ref(),
+        // accs.pyth_product7.as_ref(),
+        // accs.pyth_price7.as_ref(),
+        // accs.pyth_product8.as_ref(),
+        // accs.pyth_price8.as_ref(),
+        // accs.pyth_product9.as_ref(),
+        // accs.pyth_price9.as_ref(),
+        // accs.pyth_product10.as_ref(),
+        // accs.pyth_price10.as_ref(),
+    ];
+
+    let price_pairs: Vec<_> = price_pair_opts.into_iter().filter_map(|acc| *acc).collect();
+
+    if price_pairs.len() % 2 != 0 {
         trace!(&format!(
-            "Price's product_id does not match the pased account (points at {:?} instead)",
-            price_attestation.product_id
+            "Uneven product/price count detected: {}",
+            price_pairs.len()
         ));
         return Err(ProgramError::InvalidAccountData.into());
     }
+
+    trace!("{} Pyth symbols received", price_pairs.len() / 2);
+
+    for pair in price_pairs.as_slice().chunks_exact(2) {
+
+	let product = pair[0];
+	let price = pair[1];
+
+        if accs.config.pyth_owner != *price.owner
+            || accs.config.pyth_owner != *product.owner
+        {
+            trace!(&format!(
+            "Pair {:?} - {:?}: pyth_owner pubkey mismatch (expected {:?}, got product owner {:?} and price owner {:?}",
+		
+		product, price, 
+            accs.config.pyth_owner, product.owner, price.owner
+        ));
+            return Err(SolitaireError::InvalidOwner(accs.pyth_price.owner.clone()).into());
+        }
+
+	if accs.config.pyth_owner != *price.owner
+	    || accs.config.pyth_owner != *product.owner
+	{
+	    trace!(&format!(
+		"pyth_owner pubkey mismatch (expected {:?}, got price owner {:?} and product owner {:?}",
+		accs.config.pyth_owner, accs.pyth_price.owner, product.owner
+	    ));
+	    return Err(SolitaireError::InvalidOwner(accs.pyth_price.owner.clone()).into());
+	}
+
+    }
+
+    trace!("symbols validated OK");
+
+    // Batch the validated prices into a single Wormhole payload
+    let mut attestations = Vec::with_capacity(price_pairs.len() / 2);
+
+    for pair in price_pairs.as_slice().chunks_exact(2) {
+
+	let product = pair[0];
+	let price = pair[1];
+
+	let attestation = PriceAttestation::from_pyth_price_bytes(
+	    price.key.clone(),
+	    accs.clock.unix_timestamp,
+	    &*price.try_borrow_data()?,
+	)?;
+
+	if &attestation.product_id != product.key {
+	    trace!(&format!(
+		"Price's product_id does not match the pased account (points at {:?} instead)",
+		attestation.product_id
+	    ));
+	    return Err(ProgramError::InvalidAccountData.into());
+	}
+
+	attestations.push(attestation);
+    }
+
+    trace!("Attestations successfully created");
 
     let bridge_config = BridgeData::try_from_slice(&accs.wh_bridge.try_borrow_mut_data()?)?.config;
 
@@ -143,9 +252,9 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     let post_message_data = (
         bridge::instruction::Instruction::PostMessage,
         PostMessageData {
-            nonce: data.nonce,
-            payload: price_attestation.serialize(),
-            consistency_level: data.consistency_level,
+	    nonce: 0, // Superseded by the sequence number
+            payload: batch_serialize(attestations.as_slice().iter()),
+	    consistency_level: data.consistency_level,
         },
     );
 

--- a/solana/pyth2wormhole/program/src/config.rs
+++ b/solana/pyth2wormhole/program/src/config.rs
@@ -10,6 +10,8 @@ pub struct Pyth2WormholeConfig {
     pub wh_prog: Pubkey,
     /// Authority owning Pyth price data
     pub pyth_owner: Pubkey,
+    /// How many product/price pairs can be sent and attested at once
+    pub max_batch_size: u16,
 }
 
 impl Owned for Pyth2WormholeConfig {

--- a/solana/pyth2wormhole/program/src/types/mod.rs
+++ b/solana/pyth2wormhole/program/src/types/mod.rs
@@ -1,11 +1,13 @@
 pub mod pyth_extensions;
 
 use std::{
+    borrow::Borrow,
     convert::{
         TryFrom,
         TryInto,
     },
     io::Read,
+    iter::Iterator,
     mem,
 };
 
@@ -51,12 +53,16 @@ pub const PUBKEY_LEN: usize = 32;
 #[repr(u8)]
 pub enum PayloadId {
     PriceAttestation = 1,
+    PriceBatchAttestation,
 }
 
 // On-chain data types
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "wasm", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct PriceAttestation {
     pub product_id: Pubkey,
     pub price_id: Pubkey,
@@ -69,6 +75,84 @@ pub struct PriceAttestation {
     pub status: P2WPriceStatus,
     pub corp_act: P2WCorpAction,
     pub timestamp: UnixTimestamp,
+}
+
+/// Turn a bunch of attestations into a combined payload
+pub fn batch_serialize(
+    mut attestations: impl Iterator<Item = impl Borrow<PriceAttestation>>,
+) -> Vec<u8> {
+    // magic
+    let mut buf = P2W_MAGIC.to_vec();
+
+    // version
+    buf.extend_from_slice(&P2W_FORMAT_VERSION.to_be_bytes()[..]);
+
+    // payload_id
+    buf.push(PayloadId::PriceBatchAttestation as u8);
+
+    let collected: Vec<_> = attestations.collect();
+
+    // n_attestations
+    buf.extend_from_slice(&(collected.len() as u16).to_be_bytes()[..]);
+
+    for a in collected {
+        buf.append(&mut PriceAttestation::serialize(a.borrow()))
+    }
+    buf
+}
+
+/// Undo `batch_serialize`
+pub fn batch_deserialize(mut bytes: impl Read) -> Result<Vec<PriceAttestation>, ErrBox> {
+    let mut magic_vec = vec![0u8; P2W_MAGIC.len()];
+    bytes.read_exact(magic_vec.as_mut_slice())?;
+
+    if magic_vec.as_slice() != P2W_MAGIC {
+        return Err(format!(
+            "Invalid magic {:02X?}, expected {:02X?}",
+            magic_vec, P2W_MAGIC,
+        )
+        .into());
+    }
+
+    let mut version_vec = vec![0u8; mem::size_of_val(&P2W_FORMAT_VERSION)];
+    bytes.read_exact(version_vec.as_mut_slice())?;
+    let version = u16::from_be_bytes(version_vec.as_slice().try_into()?);
+
+    if version != P2W_FORMAT_VERSION {
+        return Err(format!(
+            "Unsupported format version {}, expected {}",
+            version, P2W_FORMAT_VERSION
+        )
+        .into());
+    }
+
+    let mut payload_id_vec = vec![0u8; mem::size_of::<PayloadId>()];
+    bytes.read_exact(payload_id_vec.as_mut_slice())?;
+
+    if payload_id_vec[0] != PayloadId::PriceBatchAttestation as u8 {
+        return Err(format!(
+            "Invalid Payload ID {}, expected {}",
+            payload_id_vec[0],
+            PayloadId::PriceBatchAttestation as u8,
+        )
+        .into());
+    }
+
+
+    let mut batch_len_vec = vec![0u8; 2];
+    bytes.read_exact(batch_len_vec.as_mut_slice())?;
+    let batch_len = u16::from_be_bytes(batch_len_vec.as_slice().try_into()?);
+
+    let mut ret = Vec::with_capacity(batch_len as usize);
+
+    for i in 0..batch_len {
+        match PriceAttestation::deserialize(&mut bytes) {
+            Ok(attestation) => ret.push(attestation),
+            Err(e) => return Err(format!("PriceAttestation {}/{}: {}", i + 1, batch_len, e).into()),
+        }
+    }
+
+    Ok(ret)
 }
 
 impl PriceAttestation {
@@ -216,20 +300,21 @@ impl PriceAttestation {
         };
 
         let mut price_vec = vec![0u8; mem::size_of::<i64>()];
-	bytes.read_exact(price_vec.as_mut_slice())?;
-	let price = i64::from_be_bytes(price_vec.as_slice().try_into()?);
+        bytes.read_exact(price_vec.as_mut_slice())?;
+        let price = i64::from_be_bytes(price_vec.as_slice().try_into()?);
 
         let mut expo_vec = vec![0u8; mem::size_of::<i32>()];
-	bytes.read_exact(expo_vec.as_mut_slice())?;
-	let expo = i32::from_be_bytes(expo_vec.as_slice().try_into()?);
+        bytes.read_exact(expo_vec.as_mut_slice())?;
+        let expo = i32::from_be_bytes(expo_vec.as_slice().try_into()?);
 
-	let twap = P2WEma::deserialize(&mut bytes)?;
-	let twac = P2WEma::deserialize(&mut bytes)?;
+        let twap = P2WEma::deserialize(&mut bytes)?;
+        let twac = P2WEma::deserialize(&mut bytes)?;
 
-	println!("twac OK");
+        println!("twac OK");
         let mut confidence_interval_vec = vec![0u8; mem::size_of::<u64>()];
-	bytes.read_exact(confidence_interval_vec.as_mut_slice())?;
-	let confidence_interval = u64::from_be_bytes(confidence_interval_vec.as_slice().try_into()?);
+        bytes.read_exact(confidence_interval_vec.as_mut_slice())?;
+        let confidence_interval =
+            u64::from_be_bytes(confidence_interval_vec.as_slice().try_into()?);
 
         let mut status_vec = vec![0u8; mem::size_of::<P2WPriceType>()];
         bytes.read_exact(status_vec.as_mut_slice())?;
@@ -243,7 +328,6 @@ impl PriceAttestation {
             }
         };
 
-
         let mut corp_act_vec = vec![0u8; mem::size_of::<P2WPriceType>()];
         bytes.read_exact(corp_act_vec.as_mut_slice())?;
         let corp_act = match corp_act_vec[0] {
@@ -253,23 +337,23 @@ impl PriceAttestation {
             }
         };
 
-	let mut timestamp_vec = vec![0u8; mem::size_of::<UnixTimestamp>()];
-			 bytes.read_exact(timestamp_vec.as_mut_slice())?;
-	let timestamp = UnixTimestamp::from_be_bytes(timestamp_vec.as_slice().try_into()?);
+        let mut timestamp_vec = vec![0u8; mem::size_of::<UnixTimestamp>()];
+        bytes.read_exact(timestamp_vec.as_mut_slice())?;
+        let timestamp = UnixTimestamp::from_be_bytes(timestamp_vec.as_slice().try_into()?);
 
-	Ok( Self {
-	    product_id,
-	    price_id,
-	    price_type,
-	    price,
-	    expo,
-	    twap,
-	    twac,
-	    confidence_interval,
-	    status,
-	    corp_act,
-	    timestamp
-	})
+        Ok(Self {
+            product_id,
+            price_id,
+            price_type,
+            price,
+            expo,
+            twap,
+            twac,
+            confidence_interval,
+            status,
+            corp_act,
+            timestamp,
+        })
     }
 }
 
@@ -404,38 +488,10 @@ mod tests {
         };
     }
 
-    #[test]
-    fn test_parse_pyth_price_wrong_size_slices() {
-        assert!(parse_pyth_price(&[]).is_err());
-        assert!(parse_pyth_price(vec![0u8; 1].as_slice()).is_err());
-    }
-
-    #[test]
-    fn test_normal_values() -> SoliResult<()> {
-        let price = Price {
-            expo: 5,
-            agg: PriceInfo {
-                price: 42,
-                ..empty_priceinfo!()
-            },
-            ..empty_price!()
-        };
-        let price_vec = vec![price];
-
-        // use the C repr to mock pyth's format
-        let (_, bytes, _) = unsafe { price_vec.as_slice().align_to::<u8>() };
-
-        parse_pyth_price(bytes)?;
-        Ok(())
-    }
-
-    #[test]
-    fn test_serialize_deserialize() -> Result<(), ErrBox> {
-        let product_id_bytes = [21u8; 32];
-        let price_id_bytes = [222u8; 32];
-        println!("Hex product_id: {:02X?}", &product_id_bytes);
-        println!("Hex price_id: {:02X?}", &price_id_bytes);
-        let attestation: PriceAttestation = PriceAttestation {
+    fn mock_attestation(prod: Option<[u8; 32]>, price: Option<[u8; 32]>) -> PriceAttestation {
+        let product_id_bytes = prod.unwrap_or([21u8; 32]);
+        let price_id_bytes = prod.unwrap_or([222u8; 32]);
+        PriceAttestation {
             product_id: Pubkey::new_from_array(product_id_bytes),
             price_id: Pubkey::new_from_array(price_id_bytes),
             price: (0xdeadbeefdeadbabe as u64) as i64,
@@ -455,14 +511,93 @@ mod tests {
             confidence_interval: 101,
             corp_act: P2WCorpAction::NoCorpAct,
             timestamp: 123456789i64,
+        }
+    }
+
+    #[test]
+    fn test_parse_pyth_price_wrong_size_slices() {
+        assert!(parse_pyth_price(&[]).is_err());
+        assert!(parse_pyth_price(vec![0u8; 1].as_slice()).is_err());
+    }
+
+    #[test]
+    fn test_parse_pyth_price() -> SoliResult<()> {
+        let price = Price {
+            expo: 5,
+            agg: PriceInfo {
+                price: 42,
+                ..empty_priceinfo!()
+            },
+            ..empty_price!()
         };
+        let price_vec = vec![price];
+
+        // use the C repr to mock pyth's format
+        let (_, bytes, _) = unsafe { price_vec.as_slice().align_to::<u8>() };
+
+        parse_pyth_price(bytes)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_attestation_serde() -> Result<(), ErrBox> {
+        let product_id_bytes = [21u8; 32];
+        let price_id_bytes = [222u8; 32];
+        let attestation: PriceAttestation = mock_attestation(Some(product_id_bytes), Some(price_id_bytes));
+
+        println!("Hex product_id: {:02X?}", &product_id_bytes);
+        println!("Hex price_id: {:02X?}", &price_id_bytes);
 
         println!("Regular: {:#?}", &attestation);
         println!("Hex: {:#02X?}", &attestation);
-	let bytes = attestation.serialize();
+        let bytes = attestation.serialize();
         println!("Hex Bytes: {:02X?}", bytes);
 
-	assert_eq!(PriceAttestation::deserialize(bytes.as_slice())?, attestation);
+        assert_eq!(
+            PriceAttestation::deserialize(bytes.as_slice())?,
+            attestation
+        );
         Ok(())
     }
+
+    #[test]
+    fn test_attestation_serde_wrong_size() -> Result<(), ErrBox> {
+        assert!(PriceAttestation::deserialize(&[][..]).is_err());
+        assert!(PriceAttestation::deserialize(vec![0u8; 1].as_slice()).is_err());
+	Ok(())
+    }
+
+    #[test]
+    fn test_batch_serde() -> Result<(), ErrBox> {
+        let attestations: Vec<_> = (0..65535)
+            .map(|i| mock_attestation(Some([(i % 256) as u8; 32]), None))
+            .collect();
+
+        let serialized = batch_serialize(attestations.iter());
+
+	let deserialized = batch_deserialize(serialized.as_slice())?;
+
+	assert_eq!(attestations, deserialized);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_serde_wrong_size() -> Result<(), ErrBox> {
+        assert!(batch_deserialize(&[][..]).is_err());
+        assert!(batch_deserialize(vec![0u8; 1].as_slice()).is_err());
+
+        let attestations: Vec<_> = (0..20)
+            .map(|i| mock_attestation(Some([(i % 256) as u8; 32]), None))
+            .collect();
+
+        let serialized = batch_serialize(attestations.iter());
+
+	// Missing last byte in last attestation must be an error
+	let len = serialized.len();
+	assert!(batch_deserialize(&serialized.as_slice()[..len-1]).is_err());
+
+	Ok(())
+    }
+
 }

--- a/solana/pyth2wormhole/program/src/wasm.rs
+++ b/solana/pyth2wormhole/program/src/wasm.rs
@@ -4,14 +4,7 @@ use wasm_bindgen::prelude::*;
 
 use std::str::FromStr;
 
-use crate::{attest::P2WEmitter, types::PriceAttestation};
-
-/// sanity check for wasm compilation, TODO(sdrozd): remove after
-/// meaningful endpoints are added
-#[wasm_bindgen]
-pub fn hello_p2w() -> String {
-    "Ciao mondo!".to_owned()
-}
+use crate::{attest::P2WEmitter, types};
 
 #[wasm_bindgen]
 pub fn get_emitter_address(program_id: String) -> Vec<u8> {
@@ -23,7 +16,15 @@ pub fn get_emitter_address(program_id: String) -> Vec<u8> {
 
 #[wasm_bindgen]
 pub fn parse_attestation(bytes: Vec<u8>) -> JsValue {
-    let a = PriceAttestation::deserialize(bytes.as_slice()).unwrap();
+    let a = types::PriceAttestation::deserialize(bytes.as_slice()).unwrap();
     
+    JsValue::from_serde(&a).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn parse_batch_attestation(bytes: Vec<u8>) -> JsValue {
+    let a = types::batch_deserialize(bytes.as_slice()).unwrap();
+    
+
     JsValue::from_serde(&a).unwrap()
 }

--- a/third_party/pyth/p2w-sdk/src/index.ts
+++ b/third_party/pyth/p2w-sdk/src/index.ts
@@ -4,12 +4,6 @@ import { PublicKey} from "@solana/web3.js";
 
 var P2W_INSTANCE: any = undefined;
 
-export async function p2wHello() {
-    const p2w = await p2w_core();
-    let s = p2w.hello_p2w();
-    console.log(s);
-}
-
 // Import p2w wasm bindings; be smart about it
 export async function p2w_core(): Promise<any> {
     // Only import once if P2W wasm is needed
@@ -37,4 +31,12 @@ export async function parseAttestation(vaa_payload: Uint8Array): Promise<any> {
     const p2w = await p2w_core();
 
     return await p2w.parse_attestation(vaa_payload);
+}
+
+export async function parseBatchAttestation(vaa_payload: Uint8Array): Promise<any> {
+    const p2w = await p2w_core();
+
+    console.log("p2w.parse_batch_attestaion is", p2w.parse_batch_attestation);
+
+    return await p2w.parse_batch_attestation(vaa_payload);
 }


### PR DESCRIPTION
**Stack**:
- #876
- #804
- #765 ⮜
- #752
- #708
- #707
- #706
- #705
- #704
- #703


<pre>
This commit introduces support for multiple Pyth product/price pairs
per call. The initial maximum batch size is 5 and is enforced using a
`P2W_MAX_BATCH_SIZE` constant.

solana/pyth2wormhole/program:
* On-chain batching logic
* Batch message parsing logic

solana/pyth2wormhole/client:
* Off-chain batching logic - divides any number of symbols into
largest possible batches
* Use a multi-symbol config file instead of CLI arguments

third_party/pyth/p2w-sdk:
* Expose batch parsing logic

third_party/pyth/p2w-relay:
* Comment out target chain calls until ETH contract supports batching
* Test the batch parsing function

third_party/pyth/p2w_<a href="autoattest.py">autoattest.py</a>:
* Generate and use the symbol config file  with pyth2wormhole-client

third_party/pyth/pyth_<a href="publisher.py">publisher.py</a>:
* Add a configurable number of mock Pyth symbols
* Adjust HTTP endpoint for multiple symbols
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/765)
<!-- Reviewable:end -->
