### PR TITLE
node/pkg/telemetry: reduce log level to INFO

### DIFF
--- a/node/cmd/guardiand/logging.go
+++ b/node/cmd/guardiand/logging.go
@@ -1,0 +1,28 @@
+package guardiand
+
+import (
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+	"unicode"
+)
+
+type consoleEncoder struct {
+	zapcore.Encoder
+}
+
+func (e consoleEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	buf, err := e.Encoder.EncodeEntry(entry, fields)
+	if err != nil {
+		buf.Free()
+		return nil, err
+	}
+
+	b := buf.Bytes()
+	for i := range b {
+		if unicode.IsControl(rune(b[i])) && !unicode.IsSpace(rune(b[i])) {
+			b[i] = '\x1A' // Substitute character
+		}
+	}
+
+	return buf, nil
+}

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -245,12 +245,11 @@ func runNode(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	cfg := zap.NewDevelopmentConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(lvl))
-	logger, err := cfg.Build()
-	if err != nil {
-		panic(err)
-	}
+	logger := zap.New(zapcore.NewCore(
+		consoleEncoder{zapcore.NewConsoleEncoder(
+			zap.NewDevelopmentEncoderConfig())},
+		zapcore.AddSync(zapcore.Lock(os.Stderr)),
+		zap.NewAtomicLevelAt(zapcore.Level(lvl))))
 
 	if *unsafeDevMode {
 		// Use the hostname as nodeName. For production, we don't want to do this to

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -293,7 +293,7 @@ func Run(obsvC chan *gossipv1.SignedObservation, sendC chan []byte, signedInC ch
 			err = proto.Unmarshal(envelope.Data, &msg)
 			if err != nil {
 				logger.Info("received invalid message",
-					zap.String("data", string(envelope.Data)),
+					zap.Binary("data", envelope.Data),
 					zap.String("from", envelope.GetFrom().String()))
 				p2pMessagesReceived.WithLabelValues("invalid").Inc()
 				continue

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/vaa"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -22,6 +23,11 @@ var (
 		prometheus.CounterOpts{
 			Name: "wormhole_aggregation_state_expirations_total",
 			Help: "Total number of expired submitted aggregation states",
+		})
+	aggregationStateLate = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_late_total",
+			Help: "Total number of late aggregation states (cluster achieved consensus without us)",
 		})
 	aggregationStateTimeout = promauto.NewCounter(
 		prometheus.CounterOpts{
@@ -58,6 +64,29 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 		delta := time.Since(s.firstObserved)
 
 		switch {
+		case !s.submitted && s.ourVAA != nil && delta > settlementTime:
+			// Expire pending VAAs post settlement time if we have a stored quorum VAA.
+			//
+			// This occurs when we observed a message after the cluster has already reached
+			// consensus on it, causing us to never achieve quorum.
+
+			if _, err := p.db.GetSignedVAABytes(*db.VaaIDFromVAA(s.ourVAA)); err == nil {
+				// If we have a stored quorum VAA, we can safely expire the state.
+				//
+				// This is a rare case, and we can safely expire the state, since we
+				// have a quorum VAA.
+				p.logger.Info("Expiring late VAA", zap.String("digest", hash), zap.Duration("delta", delta))
+				aggregationStateLate.Inc()
+				delete(p.state.vaaSignatures, hash)
+				break
+			} else if err != db.ErrVAANotFound {
+				p.logger.Error("failed to look up VAA in database",
+					zap.String("digest", hash),
+					zap.Error(err),
+				)
+			}
+
+			fallthrough
 		case !s.settled && delta > settlementTime:
 			// After 30 seconds, the VAA is considered settled - it's unlikely that more observations will
 			// arrive, barring special circumstances. This is a better time to count misses than submission,

--- a/node/pkg/telemetry/telemetry.go
+++ b/node/pkg/telemetry/telemetry.go
@@ -85,7 +85,7 @@ func (s *Telemetry) WrapLogger(logger *zap.Logger) *zap.Logger {
 	tc := zapcore.NewCore(
 		s.encoder,
 		zapcore.AddSync(ioutil.Discard),
-		zap.DebugLevel,
+		zap.InfoLevel,
 	)
 
 	return logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {


### PR DESCRIPTION
**Stack**:
- #775 ⮜
- #744
- #774


<pre>
It appears that GCP Cloud Logging cannot handle the volume of logs
we're throwing at it... full text search slows to a crawl (LOL)

Reduce log level until we can move to something else.

commit-id:b71c3467
</pre>


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*