### PR TITLE
node/pkg/solana: skip failed transactions

### DIFF
--- a/node/pkg/solana/client.go
+++ b/node/pkg/solana/client.go
@@ -299,6 +299,14 @@ OUTER:
 			continue
 		}
 
+		if tx.Meta.Err != nil {
+			logger.Debug("skipping failed Wormhole transaction",
+				zap.Stringer("signature", signature),
+				zap.Uint64("slot", slot),
+				zap.String("commitment", string(s.commitment)))
+			continue
+		}
+
 		logger.Info("found Wormhole transaction",
 			zap.Stringer("signature", signature),
 			zap.Uint64("slot", slot),


### PR DESCRIPTION
Avoid unnecessary RPC calls/retries.

Makes no difference for safety, which relies on VAA accounts rather than
any transaction metadata.

---

**Stack**:
- #821
- #798 ⮜
- #797


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*