### PR TITLE
node: increase Polygon minimum confirmation to 512

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -638,10 +638,10 @@ func runNode(cmd *cobra.Command, args []string) {
 				*polygonRPC, polygonContractAddr, "polygon", common.ReadinessPolygonSyncing, vaa.ChainIDPolygon, lockC, nil,
 				// Special case: Polygon can fork like PoW Ethereum, and it's not clear what the safe number of blocks is
 				//
-				// Hardcode the minimum number of confirmations to 256 regardless of what the smart contract specifies to protect
+				// Hardcode the minimum number of confirmations to 512 regardless of what the smart contract specifies to protect
 				// developers from accidentally specifying an unsafe number of confirmations. We can remove this restriction as soon
 				// as specific public guidance exists for Polygon developers.
-				256).Run); err != nil {
+				512).Run); err != nil {
 			return err
 		}
 		if err := supervisor.Run(ctx, "avalanchewatch",


### PR DESCRIPTION
It appears that in spite of exceeding the recommended value by 2x,
256 offers insufficient safety margin given that we saw two reorgs
of depths 178 and 187 recently: <a href="https://polygonscan.com/blocks_forked">https://polygonscan.com/blocks_forked</a>

This will increase confirmation delay from ~10 minutes to ~20 minutes.