### PR TITLE
Ensure the k8s jobs are deleted when tearing down tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 60
 
       # Clean up k8s resources
-      - run: kubectl delete --namespace=$DEPLOY_NS service,statefulset,configmap,pod --all
+      - run: kubectl delete --namespace=$DEPLOY_NS service,statefulset,configmap,pod,job --all
         if: always()
 
   # Verify whether the Makefile builds the node (no dependencies other than Go)


### PR DESCRIPTION
Otherwise, the test resources can be left between build jobs. This comes from the `Job` resource used to run the ci tests:

https://github.com/certusone/wormhole/blob/7220f4d598b0d313685caeefb8bc793f62caa337/devnet/tests.yaml#L1