### PR TITLE
Add unit-test for governance

### DIFF
--- a/node/pkg/vaa/governance_test.go
+++ b/node/pkg/vaa/governance_test.go
@@ -1,0 +1,28 @@
+package vaa
+
+import "testing"
+import "time"
+import "github.com/stretchr/testify/assert"
+
+// Testing the expected default behavior of a CreateGovernanceVAA
+func TestCreateGovernanceVAA(t *testing.T){
+	var nonce uint32 = 1
+	var sequence uint64 = 1
+	var guardianSetIndex uint32 = 1
+	var payload = []byte{97, 97, 97, 97, 97, 97}
+
+	vaa := CreateGovernanceVAA(nonce, sequence, guardianSetIndex, payload)
+
+	assert.Equal(t, vaa.Version, uint8(1))
+	assert.Equal(t, vaa.GuardianSetIndex, uint32(1))
+	assert.Nil(t, vaa.Signatures)
+	assert.Equal(t, vaa.Timestamp, time.Unix(0, 0))
+	assert.Equal(t, vaa.Timestamp, time.Unix(0, 0))
+	assert.Equal(t, vaa.Nonce, uint32(1))
+	assert.Equal(t, vaa.Sequence, uint64(1))
+	assert.Equal(t, vaa.ConsistencyLevel, uint8(32))
+	assert.Equal(t, vaa.ConsistencyLevel, uint8(32))
+	assert.Equal(t, vaa.EmitterChain, ChainIDSolana)
+	assert.Equal(t, vaa.EmitterAddress, Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4})
+	assert.Equal(t, string(vaa.Payload), "aaaaaa")
+}              

--- a/node/pkg/vaa/governance_test.go
+++ b/node/pkg/vaa/governance_test.go
@@ -5,7 +5,7 @@ import "time"
 import "github.com/stretchr/testify/assert"
 
 // Testing the expected default behavior of a CreateGovernanceVAA
-func TestCreateGovernanceVAA(t *testing.T){
+func TestCreateGovernanceVAA(t *testing.T) {
 	var nonce uint32 = 1
 	var sequence uint64 = 1
 	var guardianSetIndex uint32 = 1
@@ -25,4 +25,4 @@ func TestCreateGovernanceVAA(t *testing.T){
 	assert.Equal(t, vaa.EmitterChain, ChainIDSolana)
 	assert.Equal(t, vaa.EmitterAddress, Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4})
 	assert.Equal(t, string(vaa.Payload), "aaaaaa")
-}              
+}

--- a/node/pkg/vaa/governance_test.go
+++ b/node/pkg/vaa/governance_test.go
@@ -10,19 +10,22 @@ func TestCreateGovernanceVAA(t *testing.T) {
 	var sequence uint64 = 1
 	var guardianSetIndex uint32 = 1
 	var payload = []byte{97, 97, 97, 97, 97, 97}
+	var governanceEmitter = Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
-	vaa := CreateGovernanceVAA(nonce, sequence, guardianSetIndex, payload)
+	got_vaa := CreateGovernanceVAA(nonce, sequence, guardianSetIndex, payload)
+	
+	want_vaa := &VAA{
+		Version:          uint8(1),
+		GuardianSetIndex: uint32(1),
+		Signatures:       nil,
+		Timestamp:        time.Unix(0, 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		ConsistencyLevel: uint8(32),
+		EmitterChain:     ChainIDSolana,
+		EmitterAddress:   governanceEmitter,
+		Payload:          payload,
+	}
 
-	assert.Equal(t, vaa.Version, uint8(1))
-	assert.Equal(t, vaa.GuardianSetIndex, uint32(1))
-	assert.Nil(t, vaa.Signatures)
-	assert.Equal(t, vaa.Timestamp, time.Unix(0, 0))
-	assert.Equal(t, vaa.Timestamp, time.Unix(0, 0))
-	assert.Equal(t, vaa.Nonce, uint32(1))
-	assert.Equal(t, vaa.Sequence, uint64(1))
-	assert.Equal(t, vaa.ConsistencyLevel, uint8(32))
-	assert.Equal(t, vaa.ConsistencyLevel, uint8(32))
-	assert.Equal(t, vaa.EmitterChain, ChainIDSolana)
-	assert.Equal(t, vaa.EmitterAddress, Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4})
-	assert.Equal(t, string(vaa.Payload), "aaaaaa")
+	assert.Equal(t, got_vaa, want_vaa)
 }


### PR DESCRIPTION
This adds a unit-test for default behavior governance component of vaa.  This is a pretty simple component, so the unit-testing is mostly verifying our defaults don't shift and helps explain how to interact with the lib.  In the future, if this lib adds more functionality, we can lock in more behavior expectations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/867)
<!-- Reviewable:end -->
