### PR TITLE
Fix pyth-client-rs dependency

### DIFF
--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "git+https://github.com/pyth-network/pyth-client-rs?branch=main#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
 
 [[package]]
 name = "pyth2wormhole"

--- a/solana/pyth2wormhole/program/Cargo.toml
+++ b/solana/pyth2wormhole/program/Cargo.toml
@@ -23,7 +23,7 @@ rocksalt = { path = "../../solitaire/rocksalt" }
 solana-program = "=1.9.4"
 borsh = "=0.9.1"
 # NOTE: We're following bleeding edge to encounter format changes more easily
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", rev = "0d2689fdd4ffba09d7d77f5a52b09e16912983ec"}
 # Crates needed for easier wasm data passing
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true}
 serde = { version = "1", optional = true}

--- a/terra/Cargo.lock
+++ b/terra/Cargo.lock
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "git+https://github.com/pyth-network/pyth-client-rs?branch=main#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
 
 [[package]]
 name = "quote"

--- a/terra/contracts/pyth-bridge/Cargo.toml
+++ b/terra/contracts/pyth-bridge/Cargo.toml
@@ -31,7 +31,7 @@ generic-array = { version = "0.14.4" }
 hex = "0.4.2"
 lazy_static = "1.4.0"
 bigint = "4"
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", ref = "0d2689fdd4ffba09d7d77f5a52b09e16912983ec"}
 solana-program = "=1.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The pyth-client-rs v2 branch was merged into main, so the dependencies on the v2 branch and commit [0d2689fdd4ffba09d7d77f5a52b09e16912983ec](https://github.com/pyth-network/pyth-client-rs/commit/0d2689fdd4ffba09d7d77f5a52b09e16912983ec) were failing.

In theory, this fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/872)
<!-- Reviewable:end -->
