### PR TITLE
*: bump pyth-client to 0.2.2

### DIFF
--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -1756,7 +1756,8 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 
 [[package]]
 name = "pyth2wormhole"

--- a/solana/pyth2wormhole/program/Cargo.toml
+++ b/solana/pyth2wormhole/program/Cargo.toml
@@ -22,8 +22,7 @@ solitaire-client = { path = "../../solitaire/client", optional = true }
 rocksalt = { path = "../../solitaire/rocksalt" }
 solana-program = "=1.9.4"
 borsh = "=0.9.1"
-# NOTE: We're following bleeding edge to encounter format changes more easily
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = "0.2.2"
 # Crates needed for easier wasm data passing
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true}
 serde = { version = "1", optional = true}

--- a/terra/Cargo.lock
+++ b/terra/Cargo.lock
@@ -1338,7 +1338,8 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 
 [[package]]
 name = "quote"

--- a/terra/contracts/pyth-bridge/Cargo.toml
+++ b/terra/contracts/pyth-bridge/Cargo.toml
@@ -31,7 +31,7 @@ generic-array = { version = "0.14.4" }
 hex = "0.4.2"
 lazy_static = "1.4.0"
 bigint = "4"
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = "0.2.2"
 solana-program = "=1.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The v2 branch on the Git origin disappeared. Use the crate instead.
Updated lockfiles using `cargo update -w`.

---

**Stack**:
- #874
- #873 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/873)
<!-- Reviewable:end -->
