### PR TITLE
solana: compile wasm and contracts with --locked

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=bridge/target \
     --mount=type=cache,target=modules/token_bridge/target \
 	set -xe && \
-    cargo build --manifest-path ./bridge/Cargo.toml --package client --release && \
-    cargo build --manifest-path ./modules/token_bridge/Cargo.toml --package client --release && \
+    cargo build --manifest-path ./bridge/Cargo.toml --package client --release --locked && \
+    cargo build --manifest-path ./modules/token_bridge/Cargo.toml --package client --release --locked && \
     cp bridge/target/release/client /usr/local/bin && \
     cp modules/token_bridge/target/release/client /usr/local/bin/token-bridge-client

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -49,12 +49,12 @@ RUN --mount=type=cache,target=bridge/target \
     --mount=type=cache,target=modules/nft_bridge/target \
     --mount=type=cache,target=pyth2wormhole/target \
     --mount=type=cache,target=migration/target \
-    cargo build-bpf --manifest-path "bridge/program/Cargo.toml" && \
-    cargo build-bpf --manifest-path "bridge/cpi_poster/Cargo.toml" && \
-    cargo build-bpf --manifest-path "modules/token_bridge/program/Cargo.toml" && \
-    cargo build-bpf --manifest-path "pyth2wormhole/program/Cargo.toml" && \
-    cargo build-bpf --manifest-path "modules/nft_bridge/program/Cargo.toml" && \
-    cargo build-bpf --manifest-path "migration/Cargo.toml" && \
+    cargo build-bpf --manifest-path "bridge/program/Cargo.toml" -- --locked && \
+    cargo build-bpf --manifest-path "bridge/cpi_poster/Cargo.toml" -- --locked && \
+    cargo build-bpf --manifest-path "modules/token_bridge/program/Cargo.toml" -- --locked && \
+    cargo build-bpf --manifest-path "pyth2wormhole/program/Cargo.toml" -- --locked && \
+    cargo build-bpf --manifest-path "modules/nft_bridge/program/Cargo.toml" -- --locked && \
+    cargo build-bpf --manifest-path "migration/Cargo.toml" -- --locked && \
     cp bridge/target/deploy/bridge.so /opt/solana/deps/bridge.so && \
     cp bridge/target/deploy/cpi_poster.so /opt/solana/deps/cpi_poster.so && \
     cp migration/target/deploy/wormhole_migration.so /opt/solana/deps/wormhole_migration.so && \

--- a/solana/Dockerfile.wasm
+++ b/solana/Dockerfile.wasm
@@ -25,56 +25,58 @@ COPY pyth2wormhole pyth2wormhole
 # so we remove the non-existent function reference as a workaround.
 ARG SED_REMOVE_INVALID_REFERENCE="/^\s*wasm.__wbg_systeminstruction_free(ptr);$/d"
 
+# TODO: it appears that wasm-pack ignores our lockfiles even with --locked
+
 # Compile Wormhole
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=bridge/target \
-    cd bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm && \
+    cd bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm --locked && \
     cd bundler && sed -i $SED_REMOVE_INVALID_REFERENCE bridge_bg.js
 
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=bridge/target \
-    cd bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm
+    cd bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm --locked
 
 # Compile Token Bridge
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=modules/token_bridge/target \
-    cd modules/token_bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm && \
+    cd modules/token_bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm --locked && \
     cd bundler && sed -i $SED_REMOVE_INVALID_REFERENCE token_bridge_bg.js
 
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=modules/token_bridge/target \
-    cd modules/token_bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm
+    cd modules/token_bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm --locked
 
 # Compile Migration
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=migration/target \
-    cd migration && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm && \
+    cd migration && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm --locked && \
     cd bundler && sed -i $SED_REMOVE_INVALID_REFERENCE wormhole_migration_bg.js
 
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=migration/target \
-    cd migration && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm
+    cd migration && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm --locked
 
 # Compile NFT Bridge
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=modules/nft_bridge/target \
-    cd modules/nft_bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm && \
+    cd modules/nft_bridge/program && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm --locked && \
     cd bundler && sed -i $SED_REMOVE_INVALID_REFERENCE nft_bridge_bg.js
 
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=modules/nft_bridge/target \
-    cd modules/nft_bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm
+    cd modules/nft_bridge/program && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm --locked
 
 # Compile pyth2wormhole
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=pyth2wormhole/target \
     cd pyth2wormhole/program \
-    && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm
+    && /usr/local/cargo/bin/wasm-pack build --target bundler -d bundler -- --features wasm --locked
 
 RUN --mount=type=cache,target=/root/.cache \
 	--mount=type=cache,target=pyth2wormhole/target \
     cd pyth2wormhole/program \
-    && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm
+    && /usr/local/cargo/bin/wasm-pack build --target nodejs -d nodejs -- --features wasm --locked
 
 FROM scratch AS export
 

--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -1756,7 +1756,8 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 
 [[package]]
 name = "pyth2wormhole"

--- a/solana/pyth2wormhole/program/Cargo.toml
+++ b/solana/pyth2wormhole/program/Cargo.toml
@@ -22,8 +22,7 @@ solitaire-client = { path = "../../solitaire/client", optional = true }
 rocksalt = { path = "../../solitaire/rocksalt" }
 solana-program = "=1.9.4"
 borsh = "=0.9.1"
-# NOTE: We're following bleeding edge to encounter format changes more easily
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = "0.2.2"
 # Crates needed for easier wasm data passing
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true}
 serde = { version = "1", optional = true}

--- a/terra/Cargo.lock
+++ b/terra/Cargo.lock
@@ -1338,7 +1338,8 @@ dependencies = [
 [[package]]
 name = "pyth-client"
 version = "0.2.2"
-source = "git+https://github.com/pyth-network/pyth-client-rs?branch=v2#0d2689fdd4ffba09d7d77f5a52b09e16912983ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 
 [[package]]
 name = "quote"

--- a/terra/contracts/pyth-bridge/Cargo.toml
+++ b/terra/contracts/pyth-bridge/Cargo.toml
@@ -31,7 +31,7 @@ generic-array = { version = "0.14.4" }
 hex = "0.4.2"
 lazy_static = "1.4.0"
 bigint = "4"
-pyth-client = {git = "https://github.com/pyth-network/pyth-client-rs", branch = "v2"}
+pyth-client = "0.2.2"
 solana-program = "=1.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
When `--locked` is specified, Cargo fails hard instead of silently
ignoring the lockfile.

The argument doesn't appear to work for the wasm-bindgen, since all
the builds still complete despite an invalid lockfile. The BPF builds
fail as expected when the lockfile needs to be updated.

---

**Stack**:
- #874 ⮜
- #873


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/874)
<!-- Reviewable:end -->
