### PR TITLE
node/pkg/common: fix guardian set state cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     # (unfortunately, we can't differentiate between temporary and permanent
     # refs without duplicating the entire logic).
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-tilt-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -50,7 +50,7 @@ jobs:
     # The linter is slow enough that we want to run it on the self-hosted runner
     runs-on: tilt-kube-public
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-lint-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -189,3 +189,9 @@ Account list:
 Get yourself a working shell:
 
     kubectl exec -c goal-kmd algorand-0 -it shell-demo -- /bin/bash
+
+### guardiand debugging
+
+Use the `--guardiand_debug` Tilt argument to run guardiand within a dlv session. The session will be exposed just like
+any other Tilt services. You can then connect any IDE that supports Go debugging, like IntelliJ (add a "Go Remote"
+target and specify the host and port your Tilt instance runs on). 

--- a/Tiltfile
+++ b/Tiltfile
@@ -14,7 +14,7 @@ allow_k8s_contexts("ci")
 analytics_settings(False)
 
 # Moar updates (default is 3)
-update_settings(max_parallel_updates=10)
+update_settings(max_parallel_updates = 10)
 
 # Runtime configuration
 config.define_bool("ci", False, "We are running in CI")
@@ -46,6 +46,7 @@ config.define_bool("bridge_ui", False, "Enable bridge UI component")
 config.define_bool("e2e", False, "Enable E2E testing stack")
 config.define_bool("ci_tests", False, "Enable tests runner component")
 config.define_bool("bridge_ui_hot", False, "Enable hot loading bridge_ui")
+config.define_bool("guardiand_debug", False, "Enable dlv endpoint for guardiand")
 
 cfg = config.parse()
 num_guardians = int(cfg.get("num", "1"))
@@ -61,6 +62,7 @@ explorer = cfg.get("explorer", ci)
 bridge_ui = cfg.get("bridge_ui", ci)
 e2e = cfg.get("e2e", ci)
 ci_tests = cfg.get("ci_tests", ci)
+guardiand_debug = cfg.get("guardiand_debug", False)
 
 bridge_ui_hot = not ci
 
@@ -87,7 +89,7 @@ local_resource(
     cmd = "tilt docker build -- --target go-export -f Dockerfile.proto -o type=local,dest=node .",
     env = {"DOCKER_BUILDKIT": "1"},
     labels = ["protobuf"],
-    allow_parallel=True,
+    allow_parallel = True,
     trigger_mode = trigger_mode,
 )
 
@@ -98,7 +100,7 @@ local_resource(
     cmd = "tilt docker build -- --target node-export -f Dockerfile.proto -o type=local,dest=. .",
     env = {"DOCKER_BUILDKIT": "1"},
     labels = ["protobuf"],
-    allow_parallel=True,
+    allow_parallel = True,
     trigger_mode = trigger_mode,
 )
 
@@ -109,7 +111,7 @@ if algorand:
         cmd = "tilt docker build -- --target teal-export -f Dockerfile.teal -o type=local,dest=. .",
         env = {"DOCKER_BUILDKIT": "1"},
         labels = ["algorand"],
-        allow_parallel=True,
+        allow_parallel = True,
         trigger_mode = trigger_mode,
     )
 
@@ -123,7 +125,7 @@ if solana:
         cmd = "tilt docker build -- -f Dockerfile.wasm -o type=local,dest=.. .",
         env = {"DOCKER_BUILDKIT": "1"},
         labels = ["solana"],
-        allow_parallel=True,
+        allow_parallel = True,
         trigger_mode = trigger_mode,
     )
 
@@ -143,6 +145,19 @@ docker_build(
     dockerfile = "node/Dockerfile",
 )
 
+def command_with_dlv(argv):
+    return [
+        "/dlv",
+        "--listen=0.0.0.0:2345",
+        "--accept-multiclient",
+        "--headless=true",
+        "--api-version=2",
+        "--continue=true",
+        "exec",
+        argv[0],
+        "--",
+    ] + argv[1:]
+
 def build_node_yaml():
     node_yaml = read_yaml_stream("devnet/node.yaml")
 
@@ -153,6 +168,11 @@ def build_node_yaml():
             if container["name"] != "guardiand":
                 fail("container 0 is not guardiand")
             container["command"] += ["--devNumGuardians", str(num_guardians)]
+
+            if guardiand_debug:
+                container["command"] = command_with_dlv(container["command"])
+                container["command"] += ["--logLevel=debug"]
+                print(container["command"])
 
             if explorer:
                 container["command"] += [
@@ -205,7 +225,6 @@ k8s_resource(
 )
 
 if solana:
-
     # solana client cli (used for devnet setup)
 
     docker_build(
@@ -270,8 +289,8 @@ if solana and pyth:
     k8s_yaml_with_ns("./devnet/pyth.yaml")
 
     k8s_resource(
-        "pyth", 
-        resource_deps = ["solana-devnet"], 
+        "pyth",
+        resource_deps = ["solana-devnet"],
         labels = ["solana"],
         trigger_mode = trigger_mode,
     )
@@ -288,8 +307,8 @@ if solana and pyth:
     # Automatic pyth2wormhole relay, showcasing p2w-sdk
     docker_build(
         ref = "p2w-relay",
-	context = ".",
-	dockerfile = "./third_party/pyth/p2w-relay/Dockerfile",
+        context = ".",
+        dockerfile = "./third_party/pyth/p2w-relay/Dockerfile",
     )
 
     k8s_yaml_with_ns("devnet/p2w-attest.yaml")
@@ -426,7 +445,6 @@ if e2e:
 # bigtable
 
 if explorer:
-
     k8s_yaml_with_ns("devnet/bigtable.yaml")
 
     k8s_resource(
@@ -436,7 +454,8 @@ if explorer:
         trigger_mode = trigger_mode,
     )
 
-    k8s_resource("pubsub-emulator",
+    k8s_resource(
+        "pubsub-emulator",
         port_forwards = [port_forward(8085, name = "PubSub listeners [:8085]")],
         labels = ["explorer"],
     )

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -65,18 +65,7 @@ spec:
             - name: PUBSUB_EMULATOR_HOST
               value: pubsub-emulator:8085
           command:
-# Uncomment this to enable in-place debugging using dlv
-# (not suitable for regular development since the process will no longer restart on its own)
-#
-#            - /dlv
-#            - --listen=0.0.0.0:2345
-#            - --accept-multiclient
-#            - --headless=true
-#            - --api-version=2
-#            - --continue=true
-#            - exec
             - /guardiand
-#            - --
             - node
             - --ethRPC
             - ws://eth-devnet:8545

--- a/node/pkg/common/guardianset.go
+++ b/node/pkg/common/guardianset.go
@@ -145,7 +145,7 @@ func (st *GuardianSetState) Cleanup() {
 
 	for addr, v := range st.lastHeartbeats {
 		for peerId, hb := range v {
-			ts := time.Unix(hb.Timestamp, 0)
+			ts := time.Unix(0, hb.Timestamp)
 			if time.Since(ts) > MaxStateAge {
 				delete(st.lastHeartbeats[addr], peerId)
 			}


### PR DESCRIPTION
Proto timestamps are nanoseconds, not milliseconds.

---

**Stack**:
- #910
- #891 ⮜
- #890
- #892


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/891)
<!-- Reviewable:end -->
