### PR TITLE
.github: extend concurrency group to include workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     # (unfortunately, we can't differentiate between temporary and permanent
     # refs without duplicating the entire logic).
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-tilt-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -50,7 +50,7 @@ jobs:
     # The linter is slow enough that we want to run it on the self-hosted runner
     runs-on: tilt-kube-public
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-lint-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This potentially fixes an issue where force pushing a PR causes checks
within the same run to be cancelled.

---

**Stack**:
- #910
- #891
- #890
- #892 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/892)
<!-- Reviewable:end -->
