### PR TITLE
TVL calculation from transfer messages

### DIFF
--- a/event_database/cloud_functions/.gcloudignore
+++ b/event_database/cloud_functions/.gcloudignore
@@ -4,10 +4,13 @@
 
 .vscode
 
+.env
+
 cmd
 
 *.md
 
 *.txt
+*.json
 
 Dockerfile

--- a/event_database/cloud_functions/external-data.go
+++ b/event_database/cloud_functions/external-data.go
@@ -88,6 +88,16 @@ func chainIdToCoinGeckoPlatform(chain vaa.ChainID) string {
 		return "binance-smart-chain"
 	case vaa.ChainIDPolygon:
 		return "polygon-pos"
+	case vaa.ChainIDAvalanche:
+		return "avalanche"
+	case vaa.ChainIDOasis:
+		return "oasis"
+	case vaa.ChainIDAlgorand:
+		return "algorand"
+	case vaa.ChainIDFantom:
+		return "fantom"
+	case vaa.ChainIDEthereumRopsten:
+		return "ethereum"
 	}
 	return ""
 }

--- a/event_database/cloud_functions/go.mod
+++ b/event_database/cloud_functions/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/bigtable v1.12.0
 	cloud.google.com/go/pubsub v1.17.1
 	cloud.google.com/go/storage v1.18.2
+	github.com/GoogleCloudPlatform/functions-framework-go v1.5.3
 	github.com/certusone/wormhole/node v0.0.0-20220225194731-7e461f489cbc
 	github.com/cosmos/cosmos-sdk v0.44.0
 	github.com/gagliardetto/solana-go v1.0.2

--- a/event_database/cloud_functions/go.mod
+++ b/event_database/cloud_functions/go.mod
@@ -7,8 +7,8 @@ go 1.16
 require (
 	cloud.google.com/go/bigtable v1.12.0
 	cloud.google.com/go/pubsub v1.17.1
-	github.com/GoogleCloudPlatform/functions-framework-go v1.5.2 // indirect
-	github.com/certusone/wormhole/node v0.0.0-20211115153408-0a93202f6e5d
+	cloud.google.com/go/storage v1.18.2
+	github.com/certusone/wormhole/node v0.0.0-20220225194731-7e461f489cbc
 	github.com/cosmos/cosmos-sdk v0.44.0
 	github.com/gagliardetto/solana-go v1.0.2
 	github.com/holiman/uint256 v1.2.0

--- a/event_database/cloud_functions/go.sum
+++ b/event_database/cloud_functions/go.sum
@@ -44,6 +44,8 @@ cloud.google.com/go/bigtable v1.12.0/go.mod h1:W96Adxrf90LlA4fuB+UjFu/Y8OpoaK7y2
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
+cloud.google.com/go/functions v1.0.0 h1:cOFEDJ3sgAFRjRULSUJ0Q8cw9qFa5JdpXIBWoNX5uDw=
+cloud.google.com/go/functions v1.0.0/go.mod h1:O9KS8UweFVo6GbbbCBKh5yEzbW08PVkg2spe3RfPMd4=
 cloud.google.com/go/kms v1.0.0 h1:YkIeqPXqTAlwXk3Z2/WG0d6h1tqJQjU354WftjEoP9E=
 cloud.google.com/go/kms v1.0.0/go.mod h1:nhUehi+w7zht2XrUfvTRNpxrfayBHqP4lu2NSywui/0=
 cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
@@ -101,6 +103,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
+github.com/GoogleCloudPlatform/functions-framework-go v1.5.3 h1:Xx8uWT4hjgbjuXexbpU6V0yawWOdrbcAzZVyMYJvX8Q=
+github.com/GoogleCloudPlatform/functions-framework-go v1.5.3/go.mod h1:pq+lZy4vONJ5fjd3q/B6QzWhfHPAbuVweLpxZzMOb9Y=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -211,6 +215,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudevents/sdk-go/v2 v2.6.1 h1:yHtzgmeBvc0TZx1nrnvYXov1CSvkQyvhEhNMs8Z5Mmk=
+github.com/cloudevents/sdk-go/v2 v2.6.1/go.mod h1:nlXhgFkf0uTopxmRXalyMwS2LG70cRGPrxzmjJgSG0U=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cloudflare/cloudflare-go v0.14.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -253,6 +259,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -479,6 +486,7 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
@@ -689,6 +697,7 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -1304,6 +1313,7 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=

--- a/event_database/cloud_functions/go.sum
+++ b/event_database/cloud_functions/go.sum
@@ -44,10 +44,9 @@ cloud.google.com/go/bigtable v1.12.0/go.mod h1:W96Adxrf90LlA4fuB+UjFu/Y8OpoaK7y2
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
-cloud.google.com/go/functions v1.0.0 h1:cOFEDJ3sgAFRjRULSUJ0Q8cw9qFa5JdpXIBWoNX5uDw=
-cloud.google.com/go/functions v1.0.0/go.mod h1:O9KS8UweFVo6GbbbCBKh5yEzbW08PVkg2spe3RfPMd4=
 cloud.google.com/go/kms v1.0.0 h1:YkIeqPXqTAlwXk3Z2/WG0d6h1tqJQjU354WftjEoP9E=
 cloud.google.com/go/kms v1.0.0/go.mod h1:nhUehi+w7zht2XrUfvTRNpxrfayBHqP4lu2NSywui/0=
+cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -59,6 +58,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.18.2 h1:5NQw6tOn3eMm0oE8vTkfjau18kjL79FlMjy/CHTpmoY=
+cloud.google.com/go/storage v1.18.2/go.mod h1:AiIj7BWXyhO5gGVmYJ+S8tbkCx3yb0IMjua8Aw4naVM=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.6/go.mod h1:8x999/OcIPy5ivx/wDiV7Gx4D+VUPODf0mWRGRc5kSk=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4 h1:ksUxwH3OD5sxkjzEqGxNTl+Xjsmu3BnC/300MhSVTSc=
@@ -100,8 +101,6 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
-github.com/GoogleCloudPlatform/functions-framework-go v1.5.2 h1:fPYZMZ8BSK2jfZ28VG6vYxr/PTLbG+9USn8njzxfmWM=
-github.com/GoogleCloudPlatform/functions-framework-go v1.5.2/go.mod h1:pq+lZy4vONJ5fjd3q/B6QzWhfHPAbuVweLpxZzMOb9Y=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -199,8 +198,8 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/certusone/wormhole/node v0.0.0-20211115153408-0a93202f6e5d h1:ToxXpT4bPkE4waJY4c2ta6vqHIfVhiONyzRouU0gB1g=
-github.com/certusone/wormhole/node v0.0.0-20211115153408-0a93202f6e5d/go.mod h1:YncgdSOYam7ELyXFo7PFCj6tUo0pe6cjlj+O3Vt28mo=
+github.com/certusone/wormhole/node v0.0.0-20220225194731-7e461f489cbc h1:6WL34LK795x0qei17O5QEvKONTt5VJT3FCGRHHsl81M=
+github.com/certusone/wormhole/node v0.0.0-20220225194731-7e461f489cbc/go.mod h1:TAPmwJ1XPdSxZHWBdZjJHos0JmQM6WMCNWbT167fs1s=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -212,8 +211,6 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudevents/sdk-go/v2 v2.6.1 h1:yHtzgmeBvc0TZx1nrnvYXov1CSvkQyvhEhNMs8Z5Mmk=
-github.com/cloudevents/sdk-go/v2 v2.6.1/go.mod h1:nlXhgFkf0uTopxmRXalyMwS2LG70cRGPrxzmjJgSG0U=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cloudflare/cloudflare-go v0.14.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -256,7 +253,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -456,9 +452,11 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/martian/v3 v3.2.1 h1:d8MncMlErDFTwQGBK1xhv026j9kqhvw1Qv9IbWT1VLQ=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/orderedcode v0.0.1/go.mod h1:iVyU4/qPKHY5h/wSd6rZZCDcLJNxiWO6dvsYES2Sb20=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -481,7 +479,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
@@ -692,7 +689,6 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -1891,6 +1887,7 @@ google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210921142501-181ce0d877f6/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211008145708-270636b82663/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211016002631-37fc39342514/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211019152133-63b7e35f4404/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211027162914-98a5263abeca h1:+e+aQDO4/c9KaG8PXWHTc6/+Du6kz+BKcXCSnV4SSTE=
 google.golang.org/genproto v0.0.0-20211027162914-98a5263abeca/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=

--- a/event_database/cloud_functions/nfts.go
+++ b/event_database/cloud_functions/nfts.go
@@ -20,6 +20,8 @@ import (
 // to do a full table scan with each request.
 // https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations
 var warmNFTCache = map[string]map[string]map[string]int{}
+var muWarmNFTCache sync.RWMutex
+var warmNFTCacheFilePath = "nft-cache.json"
 
 func fetchNFTRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefix string, start, end time.Time) ([]bigtable.Row, error) {
 	rows := []bigtable.Row{}
@@ -49,7 +51,10 @@ func fetchNFTRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 }
 
 func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix string, numPrevDays int, keySegments int) (map[string]map[string]int, error) {
-	var mu sync.RWMutex
+	if _, ok := warmNFTCache["2021-09-13"]; !ok {
+		loadJsonToInterface(ctx, warmNFTCacheFilePath, &muWarmNFTCache, &warmNFTCache)
+	}
+
 	results := map[string]map[string]int{}
 
 	now := time.Now().UTC()
@@ -64,6 +69,7 @@ func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix 
 		cachePrefix = "*"
 	}
 	cachePrefix = fmt.Sprintf("%v-%v", cachePrefix, keySegments)
+	cacheNeedsUpdate := false
 
 	for daysAgo := 0; daysAgo <= numPrevDays; daysAgo++ {
 		go func(tbl *bigtable.Table, ctx context.Context, prefix string, daysAgo int) {
@@ -85,11 +91,11 @@ func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix 
 
 			dateStr := start.Format("2006-01-02")
 
-			mu.Lock()
+			muWarmNFTCache.Lock()
 			// initialize the map for this date in the result set
 			results[dateStr] = map[string]int{"*": 0}
 			// check to see if there is cache data for this date/query
-			if dateCache, ok := warmNFTCache[dateStr]; ok {
+			if dateCache, ok := warmNFTCache[dateStr]; ok && useCache(dateStr) {
 				// have a cache for this date
 
 				if val, ok := dateCache[cachePrefix]; ok {
@@ -97,7 +103,7 @@ func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix 
 					if daysAgo >= 1 {
 						// only use the cache for yesterday and older
 						results[dateStr] = val
-						mu.Unlock()
+						muWarmNFTCache.Unlock()
 						intervalsWG.Done()
 						return
 					}
@@ -110,7 +116,7 @@ func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix 
 				warmNFTCache[dateStr] = map[string]map[string]int{}
 				warmNFTCache[dateStr][cachePrefix] = map[string]int{}
 			}
-			mu.Unlock()
+			muWarmNFTCache.Unlock()
 
 			var result []bigtable.Row
 			var fetchErr error
@@ -132,12 +138,21 @@ func createNFTCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix 
 				results[dateStr][countBy] = results[dateStr][countBy] + 1
 			}
 
-			// set the result in the cache
-			warmNFTCache[dateStr][cachePrefix] = results[dateStr]
+			if cacheData, ok := warmNFTCache[dateStr][cachePrefix]; !ok || len(cacheData) <= 1 {
+				// set the result in the cache
+				muWarmNFTCache.Lock()
+				warmNFTCache[dateStr][cachePrefix] = results[dateStr]
+				muWarmNFTCache.Unlock()
+				cacheNeedsUpdate = true
+			}
 		}(tbl, ctx, prefix, daysAgo)
 	}
 
 	intervalsWG.Wait()
+
+	if cacheNeedsUpdate {
+		persistInterfaceToJson(ctx, warmNFTCacheFilePath, &muWarmNFTCache, warmNFTCache)
+	}
 
 	// create a set of all the keys from all dates, to ensure the result objects all have the same keys
 	seenKeySet := map[string]bool{}
@@ -196,12 +211,13 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 	// Set CORS headers for the main request.
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	var numDays, groupBy, forChain, forAddress string
+	var last24Hours, numDays, groupBy, forChain, forAddress string
 
 	// allow GET requests with querystring params, or POST requests with json body.
 	switch r.Method {
 	case http.MethodGet:
 		queryParams := r.URL.Query()
+		last24Hours = queryParams.Get("last24Hours")
 		numDays = queryParams.Get("numDays")
 		groupBy = queryParams.Get("groupBy")
 		forChain = queryParams.Get("forChain")
@@ -218,10 +234,11 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		// declare request body properties
 		var d struct {
-			NumDays    string `json:"numDays"`
-			GroupBy    string `json:"groupBy"`
-			ForChain   string `json:"forChain"`
-			ForAddress string `json:"forAddress"`
+			Last24Hours string `json:"last24Hours"`
+			NumDays     string `json:"numDays"`
+			GroupBy     string `json:"groupBy"`
+			ForChain    string `json:"forChain"`
+			ForAddress  string `json:"forAddress"`
 		}
 
 		// deserialize request body
@@ -236,6 +253,7 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		last24Hours = d.Last24Hours
 		numDays = d.NumDays
 		groupBy = d.GroupBy
 		forChain = d.ForChain
@@ -247,10 +265,11 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var queryDays int
-	if numDays == "" {
-		queryDays = 30
-	} else {
+	// default query period is all time
+	queryDays := int(time.Now().UTC().Sub(releaseDay).Hours() / 24)
+
+	// if the request included numDays, set the query period to that
+	if numDays != "" {
 		var convErr error
 		queryDays, convErr = strconv.Atoi(numDays)
 		if convErr != nil {
@@ -291,39 +310,22 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 
 	// total of last 24 hours
 	var last24HourCount map[string]int
-	wg.Add(1)
-	go func(prefix string, keySegments int) {
-		var err error
-		last24HourInterval := -time.Duration(24) * time.Hour
-		now := time.Now().UTC()
-		start := now.Add(last24HourInterval)
-		defer wg.Done()
-		last24HourCount, err = nftMessageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
-		if err != nil {
-			log.Printf("failed getting count for interval, err: %v", err)
-		}
-	}(prefix, keySegments)
+	if last24Hours != "" {
+		wg.Add(1)
+		go func(prefix string, keySegments int) {
+			var err error
+			last24HourInterval := -time.Duration(24) * time.Hour
+			now := time.Now().UTC()
+			start := now.Add(last24HourInterval)
+			defer wg.Done()
+			last24HourCount, err = nftMessageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
+			if err != nil {
+				log.Printf("failed getting count for interval, err: %v", err)
+			}
+		}(prefix, keySegments)
+	}
 
-	// total of the last 30 days
-	var periodCount map[string]int
-	wg.Add(1)
-	go func(prefix string, keySegments int) {
-		var err error
-		hours := (24 * queryDays)
-		periodInterval := -time.Duration(hours) * time.Hour
-
-		now := time.Now().UTC()
-		prev := now.Add(periodInterval)
-		start := time.Date(prev.Year(), prev.Month(), prev.Day(), 0, 0, 0, 0, prev.Location())
-
-		defer wg.Done()
-		periodCount, err = nftMessageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
-		if err != nil {
-			log.Fatalf("failed getting count for interval, err: %v", err)
-		}
-	}(prefix, keySegments)
-
-	// daily totals
+	periodTotals := map[string]int{}
 	var dailyTotals map[string]map[string]int
 	wg.Add(1)
 	go func(prefix string, keySegments int, queryDays int) {
@@ -331,16 +333,23 @@ func NFTs(w http.ResponseWriter, r *http.Request) {
 		defer wg.Done()
 		dailyTotals, err = createNFTCountsOfInterval(tbl, ctx, prefix, queryDays, keySegments)
 		if err != nil {
-			log.Fatalf("failed getting createCountsOfInterval err %v", err)
+			log.Fatalf("failed getting createNFTCountsOfInterval err %v", err)
+		}
+		// sum all the days to create a map with totals for the query period
+		for _, vals := range dailyTotals {
+			for chain, amount := range vals {
+				periodTotals[chain] += amount
+			}
 		}
 	}(prefix, keySegments, queryDays)
 
 	wg.Wait()
 
 	result := &totalsResult{
-		LastDayCount: last24HourCount,
-		TotalCount:   periodCount,
-		DailyTotals:  dailyTotals,
+		LastDayCount:           last24HourCount,
+		TotalCount:             periodTotals,
+		TotalCountDurationDays: queryDays,
+		DailyTotals:            dailyTotals,
 	}
 
 	jsonBytes, err := json.Marshal(result)

--- a/event_database/cloud_functions/notional-tvl-cumulative.go
+++ b/event_database/cloud_functions/notional-tvl-cumulative.go
@@ -1,0 +1,345 @@
+// Package p contains an HTTP Cloud Function.
+package p
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"sort"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+)
+
+type tvlCumulativeResult struct {
+	DailyLocked map[string]map[string]map[string]LockedAsset
+}
+
+// an in-memory cache of previously calculated results
+var warmTvlCumulativeCache = map[string]map[string]map[string]LockedAsset{}
+var muWarmTvlCumulativeCache sync.RWMutex
+var warmTvlCumulativeCacheFilePath = "tvl-cumulative-cache.json"
+
+var tvlUpToYesterday = map[string]map[string]map[string]map[string]float64{}
+var muTvlUpToYesterday sync.RWMutex
+var tvlUpToYesterdayFilePath = "tvl-up-to-yesterday-cache.json"
+
+// token addresses blacklisted from TVL calculation
+var tokensToSkip = map[string]bool{
+	"0x04132bf45511d03a58afd4f1d36a29d229ccc574": true,
+	"0xa79bd679ce21a2418be9e6f88b2186c9986bbe7d": true,
+	"0x931c3987040c90b6db09981c7c91ba155d3fa31f": true,
+	"0x8fb1a59ca2d57b51e5971a85277efe72c4492983": true,
+	"0xd52d9ba6fcbadb1fe1e3aca52cbb72c4d9bbb4ec": true,
+	"0x1353c55fd2beebd976d7acc4a7083b0618d94689": true,
+	"0xf0fbdb8a402ec0fc626db974b8d019c902deb486": true,
+	"0x1fd4a95f4335cf36cac85730289579c104544328": true,
+	"0x358aa13c52544eccef6b0add0f801012adad5ee3": true,
+	"0xbe32b7acd03bcc62f25ebabd169a35e69ef17601": true,
+	"0x7ffb3d637014488b63fb9858e279385685afc1e2": true,
+}
+
+// days to be excluded from the TVL result
+var skipDays = map[string]bool{
+	// for example:
+	// "2022-02-19": true,
+}
+
+// calcuates a running total of notional value transferred, by symbol, since the start time specified.
+func createTvlCumulativeOfInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
+	if len(warmTvlCumulativeCache) == 0 {
+		loadJsonToInterface(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, &warmTvlCumulativeCache)
+	}
+
+	now := time.Now().UTC()
+	today := now.Format("2006-01-02")
+
+	cacheNeedsUpdate := false
+	muWarmTvlCumulativeCache.Lock()
+	if len(warmTvlCumulativeCache) == 0 {
+		warmTvlCumulativeCache = map[string]map[string]map[string]LockedAsset{}
+	}
+	muWarmTvlCumulativeCache.Unlock()
+
+	results := map[string]map[string]map[string]LockedAsset{}
+
+	// fetch the amounts of transfers by symbol, for each day since launch (releaseDay)
+	dailyAmounts := tvlInInterval(tbl, ctx, releaseDay)
+
+	// create a slice of dates, order oldest first
+	dateKeys := make([]string, 0, len(dailyAmounts))
+	for k := range dailyAmounts {
+		dateKeys = append(dateKeys, k)
+	}
+	sort.Strings(dateKeys)
+
+	// iterate through the dates in the result set, and accumulate the amounts
+	// of each token transfer by symbol, based on the destination of the transfer.
+	for i, date := range dateKeys {
+		results[date] = map[string]map[string]LockedAsset{"*": {"*": LockedAsset{}}}
+		muWarmTvlCumulativeCache.RLock()
+		if dateCache, ok := warmTvlCumulativeCache[date]; ok && useCache(date) && dateCache != nil {
+			// have a cached value for this day, use it.
+			// iterate through cache and copy values to the result
+			for chain, tokens := range dateCache {
+				results[date][chain] = map[string]LockedAsset{}
+				for token, lockedAsset := range tokens {
+					results[date][chain][token] = LockedAsset{
+						Symbol:      lockedAsset.Symbol,
+						Name:        lockedAsset.Name,
+						Address:     lockedAsset.Address,
+						CoinGeckoId: lockedAsset.CoinGeckoId,
+						TokenPrice:  lockedAsset.TokenPrice,
+						Amount:      lockedAsset.Amount,
+						Notional:    lockedAsset.Notional,
+					}
+				}
+			}
+			muWarmTvlCumulativeCache.RUnlock()
+		} else {
+			// no cached value for this day, must calculate it
+			muWarmTvlCumulativeCache.RUnlock()
+			if i == 0 {
+				// special case for first day, no need to sum.
+				for chain, tokens := range dailyAmounts[date] {
+					results[date][chain] = map[string]LockedAsset{}
+					for token, lockedAsset := range tokens {
+						results[date][chain][token] = LockedAsset{
+							Symbol:      lockedAsset.Symbol,
+							Name:        lockedAsset.Name,
+							Address:     lockedAsset.Address,
+							CoinGeckoId: lockedAsset.CoinGeckoId,
+							TokenPrice:  lockedAsset.TokenPrice,
+							Amount:      lockedAsset.Amount,
+							Notional:    lockedAsset.Notional,
+						}
+					}
+				}
+			} else {
+				// find the string of the previous day
+				prevDate := dateKeys[i-1]
+				prevDayAmounts := results[prevDate]
+				thisDayAmounts := dailyAmounts[date]
+				// iterate through all the transfers and add the previous day's amount, if it exists
+				for chain, thisDaySymbols := range thisDayAmounts {
+					// create a union of the symbols from this day, and previous days
+					symbolsUnion := map[string]string{}
+					for symbol := range prevDayAmounts[chain] {
+						symbolsUnion[symbol] = symbol
+					}
+					for symbol := range thisDaySymbols {
+						symbolsUnion[symbol] = symbol
+					}
+					// initalize the chain/symbol map for this date
+					if _, ok := results[date][chain]; !ok {
+						results[date][chain] = map[string]LockedAsset{}
+					}
+					// iterate through the union of symbols, creating an amount for each one,
+					// and adding it the the results.
+					for symbol := range symbolsUnion {
+
+						asset := LockedAsset{}
+
+						prevDayAmount := float64(0)
+						if lockedAsset, ok := results[prevDate][chain][symbol]; ok {
+							prevDayAmount = lockedAsset.Amount
+							asset = lockedAsset
+						}
+
+						thisDayAmount := float64(0)
+						if lockedAsset, ok := thisDaySymbols[symbol]; ok {
+							thisDayAmount = lockedAsset.Amount
+							// use today's locked asset, rather than prevDay's, for freshest price.
+							asset = lockedAsset
+						}
+						cumulativeAmount := prevDayAmount + thisDayAmount
+
+						results[date][chain][symbol] = LockedAsset{
+							Symbol:      asset.Symbol,
+							Name:        asset.Name,
+							Address:     asset.Address,
+							CoinGeckoId: asset.CoinGeckoId,
+							TokenPrice:  asset.TokenPrice,
+							Amount:      cumulativeAmount,
+						}
+					}
+				}
+			}
+			// dont cache today
+			if date != today {
+				// set the result in the cache
+				muWarmTvlCumulativeCache.Lock()
+				if _, ok := warmTvlCumulativeCache[date]; !ok || !useCache(date) {
+					// cache does not have this date, persist it for other instances.
+					warmTvlCumulativeCache[date] = map[string]map[string]LockedAsset{}
+					for chain, tokens := range results[date] {
+						warmTvlCumulativeCache[date][chain] = map[string]LockedAsset{}
+						for token, asset := range tokens {
+							warmTvlCumulativeCache[date][chain][token] = LockedAsset{
+								Symbol:      asset.Symbol,
+								Name:        asset.Name,
+								Address:     asset.Address,
+								CoinGeckoId: asset.CoinGeckoId,
+								TokenPrice:  asset.TokenPrice,
+								Amount:      asset.Amount,
+							}
+						}
+					}
+					cacheNeedsUpdate = true
+				}
+				muWarmTvlCumulativeCache.Unlock()
+
+			}
+		}
+	}
+
+	if cacheNeedsUpdate {
+		persistInterfaceToJson(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, warmTvlCumulativeCache)
+	}
+
+	// take the most recent n days, rather than returning all days since launch
+	selectDays := map[string]map[string]map[string]LockedAsset{}
+	days := getDaysInRange(start, now)
+	for _, day := range days {
+		selectDays[day] = map[string]map[string]LockedAsset{}
+		for chain, tokens := range results[day] {
+			selectDays[day][chain] = map[string]LockedAsset{}
+			for symbol, asset := range tokens {
+				selectDays[day][chain][symbol] = LockedAsset{
+					Symbol:      asset.Symbol,
+					Name:        asset.Name,
+					Address:     asset.Address,
+					CoinGeckoId: asset.CoinGeckoId,
+					TokenPrice:  asset.TokenPrice,
+					Amount:      asset.Amount,
+				}
+			}
+		}
+	}
+	return selectDays
+
+}
+
+// calculates the cumulative value transferred each day since launch.
+func TvlCumulative(w http.ResponseWriter, r *http.Request) {
+	// Set CORS headers for the preflight request
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "3600")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// Set CORS headers for the main request.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// get the number of days to query - days since launch day
+	queryDays := int(time.Now().UTC().Sub(releaseDay).Hours() / 24)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
+	defer cancel()
+
+	dailyTvl := map[string]map[string]map[string]LockedAsset{}
+
+	hours := (24 * queryDays)
+	periodInterval := -time.Duration(hours) * time.Hour
+	now := time.Now().UTC()
+	prev := now.Add(periodInterval)
+	start := time.Date(prev.Year(), prev.Month(), prev.Day(), 0, 0, 0, 0, prev.Location())
+
+	transfers := createTvlCumulativeOfInterval(tbl, ctx, start)
+
+	// calculate the notional tvl based on the price of the tokens each day
+	for date, chains := range transfers {
+		if _, ok := skipDays[date]; ok {
+			log.Println("skipping ", date)
+			continue
+		}
+		dailyTvl[date] = map[string]map[string]LockedAsset{}
+		dailyTvl[date]["*"] = map[string]LockedAsset{}
+		dailyTvl[date]["*"]["*"] = LockedAsset{
+			Symbol:      "*",
+			Address:     "",
+			CoinGeckoId: "",
+			TokenPrice:  0,
+			Amount:      0,
+			Notional:    0,
+		}
+		for chain, tokens := range chains {
+			if chain == "*" {
+				continue
+			}
+			dailyTvl[date][chain] = map[string]LockedAsset{}
+			dailyTvl[date][chain]["*"] = LockedAsset{
+				Symbol:      "*",
+				Address:     "",
+				CoinGeckoId: "",
+				TokenPrice:  0,
+				Amount:      0,
+				Notional:    0,
+			}
+
+			for symbol, asset := range tokens {
+				if symbol == "*" {
+					continue
+				}
+				if _, ok := tokensToSkip[symbol]; ok {
+					log.Printf("going to skip %v, on chain %v, date %v", asset.Symbol, chain, date)
+					continue
+				}
+
+				notional := asset.Amount * asset.TokenPrice
+				if notional <= 0 {
+					log.Printf("skipping token with no/negative value. notional: %v, chain: %v, symbol %v, address %v", notional, chain, asset.Symbol, asset.Address)
+					continue
+				}
+
+				asset.Notional = roundToTwoDecimalPlaces(notional)
+				dailyTvl[date][chain][symbol] = asset
+
+				// add this asset's notional to the date/chain/*
+				if allAssets, ok := dailyTvl[date][chain]["*"]; ok {
+					allAssets.Notional += notional
+					dailyTvl[date][chain]["*"] = allAssets
+				}
+			} // end symbols iteration
+
+			// add chain total to the daily total
+			if allAssets, ok := dailyTvl[date]["*"]["*"]; ok {
+				allAssets.Notional += dailyTvl[date][chain]["*"].Notional
+				dailyTvl[date]["*"]["*"] = allAssets
+			}
+
+			// round the day's chain total
+			if allAssets, ok := dailyTvl[date][chain]["*"]; ok {
+				allAssets.Notional = roundToTwoDecimalPlaces(allAssets.Notional)
+				dailyTvl[date][chain]["*"] = allAssets
+			}
+		} // end chains iteration
+
+		// round the daily total
+		if allAssets, ok := dailyTvl[date]["*"]["*"]; ok {
+			allAssets.Notional = roundToTwoDecimalPlaces(allAssets.Notional)
+			dailyTvl[date]["*"]["*"] = allAssets
+		}
+	}
+
+	result := &tvlCumulativeResult{
+		DailyLocked: dailyTvl,
+	}
+
+	jsonBytes, err := json.Marshal(result)
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		log.Println(err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonBytes)
+}

--- a/event_database/cloud_functions/notional-tvl-cumulative.go
+++ b/event_database/cloud_functions/notional-tvl-cumulative.go
@@ -51,7 +51,7 @@ var skipDays = map[string]bool{
 // calcuates a running total of notional value transferred, by symbol, since the start time specified.
 func createTvlCumulativeOfInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
 	if len(warmTvlCumulativeCache) == 0 {
-		loadJsonToInterface(warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, &warmTvlCumulativeCache)
+		loadJsonToInterface(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, &warmTvlCumulativeCache)
 	}
 
 	now := time.Now().UTC()
@@ -197,7 +197,7 @@ func createTvlCumulativeOfInterval(tbl *bigtable.Table, ctx context.Context, sta
 	}
 
 	if cacheNeedsUpdate {
-		persistInterfaceToJson(warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, warmTvlCumulativeCache)
+		persistInterfaceToJson(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, warmTvlCumulativeCache)
 	}
 
 	// take the most recent n days, rather than returning all days since launch

--- a/event_database/cloud_functions/notional-tvl-cumulative.go
+++ b/event_database/cloud_functions/notional-tvl-cumulative.go
@@ -51,7 +51,7 @@ var skipDays = map[string]bool{
 // calcuates a running total of notional value transferred, by symbol, since the start time specified.
 func createTvlCumulativeOfInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
 	if len(warmTvlCumulativeCache) == 0 {
-		loadJsonToInterface(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, &warmTvlCumulativeCache)
+		loadJsonToInterface(warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, &warmTvlCumulativeCache)
 	}
 
 	now := time.Now().UTC()
@@ -197,7 +197,7 @@ func createTvlCumulativeOfInterval(tbl *bigtable.Table, ctx context.Context, sta
 	}
 
 	if cacheNeedsUpdate {
-		persistInterfaceToJson(ctx, warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, warmTvlCumulativeCache)
+		persistInterfaceToJson(warmTvlCumulativeCacheFilePath, &muWarmTvlCumulativeCache, warmTvlCumulativeCache)
 	}
 
 	// take the most recent n days, rather than returning all days since launch

--- a/event_database/cloud_functions/notional-tvl.go
+++ b/event_database/cloud_functions/notional-tvl.go
@@ -36,7 +36,7 @@ type LockedAsset struct {
 // finds the daily amount of each symbol transferred to each chain, from the specified start to the present.
 func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
 	if len(warmTvlCache) == 0 {
-		loadJsonToInterface(ctx, warmTvlFilePath, &muWarmTvlCache, &warmTvlCache)
+		loadJsonToInterface(warmTvlFilePath, &muWarmTvlCache, &warmTvlCache)
 	}
 
 	results := map[string]map[string]map[string]LockedAsset{}
@@ -162,7 +162,7 @@ func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) ma
 	intervalsWG.Wait()
 
 	if cacheNeedsUpdate {
-		persistInterfaceToJson(ctx, warmTvlFilePath, &muWarmTvlCache, warmTvlCache)
+		persistInterfaceToJson(warmTvlFilePath, &muWarmTvlCache, warmTvlCache)
 	}
 
 	// create a set of all the keys from all dates/chains, to ensure the result objects all have the same chain keys

--- a/event_database/cloud_functions/notional-tvl.go
+++ b/event_database/cloud_functions/notional-tvl.go
@@ -358,6 +358,14 @@ func TVL(w http.ResponseWriter, r *http.Request) {
 		tokenPrices := fetchTokenPrices(ctx, coinIdSet)
 
 		notionalLocked := map[string]map[string]LockedAsset{}
+
+		// initialize the struct that will hold the total for all chains, all assets
+		notionalLocked["*"] = map[string]LockedAsset{}
+		notionalLocked["*"]["*"] = LockedAsset{
+			Symbol:   "*",
+			Name:     "all",
+			Notional: 0,
+		}
 		for chain, tokens := range tokensLocked {
 			notionalLocked[chain] = map[string]LockedAsset{}
 			notionalLocked[chain]["*"] = LockedAsset{
@@ -392,6 +400,12 @@ func TVL(w http.ResponseWriter, r *http.Request) {
 					}
 
 				}
+			}
+
+			// add the chain total to the overall total
+			if all, ok := notionalLocked["*"]["*"]; ok {
+				all.Notional += notionalLocked[chain]["*"].Notional
+				notionalLocked["*"]["*"] = all
 			}
 
 			// round the the amount for chain/*

--- a/event_database/cloud_functions/notional-tvl.go
+++ b/event_database/cloud_functions/notional-tvl.go
@@ -1,0 +1,448 @@
+// Package p contains an HTTP Cloud Function.
+package p
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+)
+
+type tvlResult struct {
+	Last24HoursChange map[string]map[string]LockedAsset
+	AllTime           map[string]map[string]LockedAsset
+}
+
+// an in-memory cache of previously calculated results
+var warmTvlCache = map[string]map[string]map[string]LockedAsset{}
+var muWarmTvlCache sync.RWMutex
+var warmTvlFilePath = "tvl-cache.json"
+
+type LockedAsset struct {
+	Symbol      string
+	Name        string
+	Address     string
+	CoinGeckoId string
+	Amount      float64
+	Notional    float64
+	TokenPrice  float64
+}
+
+// finds the daily amount of each symbol transferred to each chain, from the specified start to the present.
+func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
+	if len(warmTvlCache) == 0 {
+		loadJsonToInterface(ctx, warmTvlFilePath, &muWarmTvlCache, &warmTvlCache)
+	}
+
+	results := map[string]map[string]map[string]LockedAsset{}
+
+	now := time.Now().UTC()
+	numPrevDays := int(now.Sub(start).Hours() / 24)
+
+	var intervalsWG sync.WaitGroup
+	// there will be a query for each previous day, plus today
+	intervalsWG.Add(numPrevDays + 1)
+
+	cacheNeedsUpdate := false
+
+	for daysAgo := 0; daysAgo <= numPrevDays; daysAgo++ {
+		go func(tbl *bigtable.Table, ctx context.Context, daysAgo int) {
+			// start is the SOD, end is EOD
+			// "0 daysAgo start" is 00:00:00 AM of the current day
+			// "0 daysAgo end" is 23:59:59 of the current day (the future)
+
+			// calulate the start and end times for the query
+			hoursAgo := (24 * daysAgo)
+			daysAgoDuration := -time.Duration(hoursAgo) * time.Hour
+			n := now.Add(daysAgoDuration)
+			year := n.Year()
+			month := n.Month()
+			day := n.Day()
+			loc := n.Location()
+
+			start := time.Date(year, month, day, 0, 0, 0, 0, loc)
+			end := time.Date(year, month, day, 23, 59, 59, maxNano, loc)
+
+			dateStr := start.Format("2006-01-02")
+
+			muWarmTvlCache.Lock()
+			// initialize the map for this date in the result set
+			results[dateStr] = map[string]map[string]LockedAsset{}
+			// check to see if there is cache data for this date/query
+			if len(warmTvlCache) >= 1 {
+				// have a cache, check if has the date
+
+				if dateCache, ok := warmTvlCache[dateStr]; ok && useCache(dateStr) && len(dateCache) > 1 {
+					// have a cache for this date
+					if daysAgo >= 1 {
+						// only use the cache for yesterday and older
+						results[dateStr] = dateCache
+						muWarmTvlCache.Unlock()
+						intervalsWG.Done()
+						return
+					}
+				}
+			} else {
+				// no cache for this query, initialize the map
+				warmTvlCache = map[string]map[string]map[string]LockedAsset{}
+			}
+			muWarmTvlCache.Unlock()
+
+			defer intervalsWG.Done()
+
+			queryResult := fetchTransferRowsInInterval(tbl, ctx, "", start, end)
+
+			// iterate through the rows and increment the count
+			for _, row := range queryResult {
+				if row.CoinGeckoCoinId == "" {
+					log.Printf("skipping row without CoinGeckoCoinId. symbol: %v, amount %v", row.TokenSymbol, row.TokenAmount)
+					continue
+				}
+				if _, ok := tokensToSkip[row.TokenAddress]; ok {
+					// skip blacklisted token
+					continue
+				}
+				if row.TokenAddress == "" {
+					// if the token adress is missing, skip
+					continue
+				}
+
+				if _, ok := results[dateStr][row.OriginChain]; !ok {
+					results[dateStr][row.OriginChain] = map[string]LockedAsset{}
+				}
+
+				if _, ok := results[dateStr][row.OriginChain][row.TokenAddress]; !ok {
+					results[dateStr][row.OriginChain][row.TokenAddress] = LockedAsset{
+						Symbol:      row.TokenSymbol,
+						Name:        row.TokenName,
+						Address:     row.TokenAddress,
+						CoinGeckoId: row.CoinGeckoCoinId,
+						TokenPrice:  row.TokenPrice,
+						Amount:      0,
+						Notional:    0,
+					}
+				}
+
+				var amountChange float64
+				amountChange = 0
+				if row.OriginChain == row.LeavingChain {
+					// this is a native asset leaving its chain:
+					// add this to tokens of originChain
+					amountChange = row.TokenAmount
+				}
+				if row.OriginChain == row.DestinationChain {
+					// this is a native asset going back to its chain:
+					// subtract this from tokens of originChain
+					amountChange = row.TokenAmount * -1
+				}
+
+				if prevForChain, ok := results[dateStr][row.OriginChain][row.TokenAddress]; ok {
+					prevForChain.Amount = prevForChain.Amount + amountChange
+					results[dateStr][row.OriginChain][row.TokenAddress] = prevForChain
+				}
+			}
+			if daysAgo >= 1 {
+				// set the result in the cache
+				muWarmTvlCache.Lock()
+				if cacheData, ok := warmTvlCache[dateStr]; !ok || len(cacheData) <= 1 || !useCache(dateStr) {
+					// cache does not have this date, persist it for other instances.
+					warmTvlCache[dateStr] = results[dateStr]
+					cacheNeedsUpdate = true
+				}
+				muWarmTvlCache.Unlock()
+			}
+		}(tbl, ctx, daysAgo)
+	}
+
+	intervalsWG.Wait()
+
+	if cacheNeedsUpdate {
+		persistInterfaceToJson(ctx, warmTvlFilePath, &muWarmTvlCache, warmTvlCache)
+	}
+
+	// create a set of all the keys from all dates/chains, to ensure the result objects all have the same chain keys
+	seenChainSet := map[string]bool{}
+	for _, chains := range results {
+		for leaving := range chains {
+			if _, ok := seenChainSet[leaving]; !ok {
+				seenChainSet[leaving] = true
+			}
+		}
+	}
+
+	var muResult sync.RWMutex
+	// ensure each chain object has all the same symbol keys:
+	for date, chains := range results {
+		// loop through seen chains
+		for chain := range seenChainSet {
+			// check that date has all the chains
+			if _, ok := chains[chain]; !ok {
+				muResult.Lock()
+				results[date][chain] = map[string]LockedAsset{}
+				muResult.Unlock()
+			}
+		}
+	}
+
+	return results
+}
+
+// adds dailyTotals to return a map with chainIds for keys, each value is a map of address/amount locked.
+func tvlSinceDate(tbl *bigtable.Table, ctx context.Context, dailyTotals map[string]map[string]map[string]LockedAsset) map[string]map[string]LockedAsset {
+	result := map[string]map[string]LockedAsset{}
+
+	// loop through the query results to combine cache + fresh data
+	for _, chains := range dailyTotals {
+		for chain, tokens := range chains {
+			// ensure the chain exists in the result map
+			if _, ok := result[chain]; !ok {
+				result[chain] = map[string]LockedAsset{}
+			}
+			for address, lockedAsset := range tokens {
+				amount := lockedAsset.Amount
+				if asset, ok := result[chain][address]; ok {
+					// add the amount of this symbol transferred this day to the
+					// amount already in the result (amount of this symbol prevoiusly transferred)
+					asset.Amount = asset.Amount + amount
+					result[chain][address] = asset
+				} else {
+					// have not seen this asset in previous days
+					result[chain][address] = LockedAsset{
+						Symbol:      lockedAsset.Symbol,
+						Name:        lockedAsset.Name,
+						Address:     lockedAsset.Address,
+						CoinGeckoId: lockedAsset.CoinGeckoId,
+						Amount:      lockedAsset.Amount,
+						TokenPrice:  lockedAsset.TokenPrice,
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// returns the count of the rows in the query response
+func tvlForInterval(tbl *bigtable.Table, ctx context.Context, start, end time.Time) map[string]map[string]LockedAsset {
+	// query for all rows in time range, return result count
+	queryResults := fetchTransferRowsInInterval(tbl, ctx, "", start, end)
+
+	result := map[string]map[string]LockedAsset{}
+
+	// iterate through the rows and increment the count for each index
+	for _, row := range queryResults {
+		if _, ok := result[row.OriginChain]; !ok {
+			result[row.OriginChain] = map[string]LockedAsset{}
+		}
+		if row.TokenAddress == "" {
+			// if the token address is missing, skip
+			continue
+		}
+		if _, ok := result[row.OriginChain][row.TokenAddress]; !ok {
+			result[row.OriginChain][row.TokenAddress] = LockedAsset{
+				Symbol:      row.TokenSymbol,
+				Name:        row.TokenName,
+				Address:     row.TokenAddress,
+				CoinGeckoId: row.CoinGeckoCoinId,
+				Amount:      0,
+				Notional:    0,
+			}
+		}
+
+		var amountChange float64
+		amountChange = 0
+		// track notional changes for the previous 24 hour delta
+		var notionalChange float64
+		notionalChange = 0
+		if row.OriginChain == row.LeavingChain {
+			// this is a native asset leaving its chain:
+			// add this to tvl of originChain
+			amountChange = row.TokenAmount
+			notionalChange = row.Notional
+		}
+		if row.OriginChain == row.DestinationChain {
+			// this is a native asset going back to its chain:
+			// subtract this from tvl of originChain
+			amountChange = row.TokenAmount * -1
+			notionalChange = row.Notional * -1
+		}
+
+		if prevForChain, ok := result[row.OriginChain][row.TokenAddress]; ok {
+			prevForChain.Amount = prevForChain.Amount + amountChange
+			prevForChain.Notional = prevForChain.Notional + notionalChange
+			result[row.OriginChain][row.TokenAddress] = prevForChain
+		}
+
+		if prevAllChains, ok := result["*"][row.TokenAddress]; ok {
+			prevAllChains.Amount = prevAllChains.Amount + amountChange
+			prevAllChains.Notional = prevAllChains.Notional + notionalChange
+			result["*"][row.TokenAddress] = prevAllChains
+		}
+	}
+	return result
+}
+
+// calculates the value locked
+func TVL(w http.ResponseWriter, r *http.Request) {
+	// Set CORS headers for the preflight request
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "3600")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// Set CORS headers for the main request.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	var last24Hours string
+
+	// allow GET requests with querystring params, or POST requests with json body.
+	switch r.Method {
+	case http.MethodGet:
+		queryParams := r.URL.Query()
+		last24Hours = queryParams.Get("last24Hours")
+
+	case http.MethodPost:
+		// declare request body properties
+		var d struct {
+			Last24Hours string `json:"last24Hours"`
+		}
+
+		// deserialize request body
+		if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+			switch err {
+			case io.EOF:
+				// do nothing, empty body is ok
+			default:
+				log.Printf("json.NewDecoder: %v", err)
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+		}
+
+		last24Hours = d.Last24Hours
+
+	default:
+		http.Error(w, "405 - Method Not Allowed", http.StatusMethodNotAllowed)
+		log.Println("Method Not Allowed")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
+	defer cancel()
+
+	getNotionalAmounts := func(ctx context.Context, tokensLocked map[string]map[string]LockedAsset) map[string]map[string]LockedAsset {
+		// create a map of all the coinIds
+		seenCoinIds := map[string]bool{}
+		for _, tokens := range tokensLocked {
+			for _, lockedAsset := range tokens {
+				coinId := lockedAsset.CoinGeckoId
+				if coinId != "*" {
+					seenCoinIds[coinId] = true
+				}
+			}
+		}
+		coinIdSet := []string{}
+		for coinId, _ := range seenCoinIds {
+			coinIdSet = append(coinIdSet, coinId)
+		}
+
+		tokenPrices := fetchTokenPrices(ctx, coinIdSet)
+
+		notionalLocked := map[string]map[string]LockedAsset{}
+		for chain, tokens := range tokensLocked {
+			notionalLocked[chain] = map[string]LockedAsset{}
+			notionalLocked[chain]["*"] = LockedAsset{
+				Symbol:  "all",
+				Address: "*",
+			}
+			for address, lockedAsset := range tokens {
+
+				coinId := lockedAsset.CoinGeckoId
+				amount := lockedAsset.Amount
+				if address != "*" {
+					currentPrice := tokenPrices[coinId]
+					notionalVal := amount * currentPrice
+					if notionalVal <= 0 {
+						log.Printf("skipping token with no value. chain: %v, symbol %v, address %v", chain, lockedAsset.Symbol, lockedAsset.Address)
+						continue
+					}
+
+					notionalLocked[chain][address] = LockedAsset{
+						Symbol:      lockedAsset.Symbol,
+						Name:        lockedAsset.Name,
+						Address:     lockedAsset.Address,
+						CoinGeckoId: lockedAsset.CoinGeckoId,
+						Amount:      lockedAsset.Amount,
+						Notional:    roundToTwoDecimalPlaces(notionalVal),
+						TokenPrice:  currentPrice,
+					}
+
+					if asset, ok := notionalLocked[chain]["*"]; ok {
+						asset.Notional = asset.Notional + notionalVal
+						notionalLocked[chain]["*"] = asset
+					}
+
+				}
+			}
+
+			// round the the amount for chain/*
+			if asset, ok := notionalLocked[chain]["*"]; ok {
+				asset.Notional = roundToTwoDecimalPlaces(asset.Notional)
+				notionalLocked[chain]["*"] = asset
+			}
+		}
+		return notionalLocked
+	}
+
+	var wg sync.WaitGroup
+
+	// delta of last 24 hours
+	last24HourDelta := map[string]map[string]LockedAsset{}
+	if last24Hours != "" {
+		wg.Add(1)
+		go func() {
+			last24HourInterval := -time.Duration(24) * time.Hour
+			now := time.Now().UTC()
+			start := now.Add(last24HourInterval)
+			defer wg.Done()
+			transfers := tvlForInterval(tbl, ctx, start, now)
+			last24HourDelta = getNotionalAmounts(ctx, transfers)
+		}()
+	}
+
+	// total since release
+	allTimeLocked := map[string]map[string]LockedAsset{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		dailyTotalsAllTime := tvlInInterval(tbl, ctx, releaseDay)
+		transfers := tvlSinceDate(tbl, ctx, dailyTotalsAllTime)
+		allTimeLocked = getNotionalAmounts(ctx, transfers)
+	}()
+
+	wg.Wait()
+
+	result := &tvlResult{
+		Last24HoursChange: last24HourDelta,
+		AllTime:           allTimeLocked,
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		log.Println(err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonBytes)
+}

--- a/event_database/cloud_functions/notional-tvl.go
+++ b/event_database/cloud_functions/notional-tvl.go
@@ -36,7 +36,7 @@ type LockedAsset struct {
 // finds the daily amount of each symbol transferred to each chain, from the specified start to the present.
 func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) map[string]map[string]map[string]LockedAsset {
 	if len(warmTvlCache) == 0 {
-		loadJsonToInterface(warmTvlFilePath, &muWarmTvlCache, &warmTvlCache)
+		loadJsonToInterface(ctx, warmTvlFilePath, &muWarmTvlCache, &warmTvlCache)
 	}
 
 	results := map[string]map[string]map[string]LockedAsset{}
@@ -77,7 +77,7 @@ func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) ma
 			if len(warmTvlCache) >= 1 {
 				// have a cache, check if has the date
 
-				if dateCache, ok := warmTvlCache[dateStr]; ok && useCache(dateStr) && len(dateCache) > 1 {
+				if dateCache, ok := warmTvlCache[dateStr]; ok && len(dateCache) > 1 && useCache(dateStr) {
 					// have a cache for this date
 					if daysAgo >= 1 {
 						// only use the cache for yesterday and older
@@ -162,7 +162,7 @@ func tvlInInterval(tbl *bigtable.Table, ctx context.Context, start time.Time) ma
 	intervalsWG.Wait()
 
 	if cacheNeedsUpdate {
-		persistInterfaceToJson(warmTvlFilePath, &muWarmTvlCache, warmTvlCache)
+		persistInterfaceToJson(ctx, warmTvlFilePath, &muWarmTvlCache, warmTvlCache)
 	}
 
 	// create a set of all the keys from all dates/chains, to ensure the result objects all have the same chain keys
@@ -351,7 +351,7 @@ func TVL(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		coinIdSet := []string{}
-		for coinId, _ := range seenCoinIds {
+		for coinId := range seenCoinIds {
 			coinIdSet = append(coinIdSet, coinId)
 		}
 

--- a/event_database/cloud_functions/shared.go
+++ b/event_database/cloud_functions/shared.go
@@ -462,6 +462,19 @@ func createCachePrefix(prefix string) string {
 	return cachePrefix
 }
 
+// useCache allows overriding the cache for a given day.
+// This is useful for debugging, to generate fresh data
+func useCache(date string) bool {
+	skipDates := map[string]bool{
+		// for example, add to skip:
+		// "2022-02-01": true,
+	}
+	if _, ok := skipDates[date]; ok {
+		return false
+	}
+	return true
+}
+
 var mux = newMux()
 
 // Entry is the cloud function entry point

--- a/event_database/cloud_functions/totals.go
+++ b/event_database/cloud_functions/totals.go
@@ -20,15 +20,18 @@ import (
 const maxNano int = 999999999
 
 type totalsResult struct {
-	LastDayCount map[string]int
-	TotalCount   map[string]int
-	DailyTotals  map[string]map[string]int
+	LastDayCount           map[string]int
+	TotalCount             map[string]int
+	TotalCountDurationDays int
+	DailyTotals            map[string]map[string]int
 }
 
 // warmCache keeps some data around between invocations, so that we don't have
 // to do a full table scan with each request.
 // https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations
 var warmTotalsCache = map[string]map[string]map[string]int{}
+var muWarmTotalsCache sync.RWMutex
+var warmTotalsCacheFilePath = "totals-cache.json"
 
 // derive the result index relevant to a row.
 func makeGroupKey(keySegments int, rowKey string) string {
@@ -63,7 +66,10 @@ func fetchRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefix string
 }
 
 func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix string, numPrevDays int, keySegments int) (map[string]map[string]int, error) {
-	var mu sync.RWMutex
+	if _, ok := warmTotalsCache["2021-09-13"]; !ok {
+		loadJsonToInterface(ctx, warmTotalsCacheFilePath, &muWarmTotalsCache, &warmTotalsCache)
+	}
+
 	results := map[string]map[string]int{}
 
 	now := time.Now().UTC()
@@ -78,6 +84,7 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 		cachePrefix = "*"
 	}
 	cachePrefix = fmt.Sprintf("%v-%v", cachePrefix, keySegments)
+	cacheNeedsUpdate := false
 
 	for daysAgo := 0; daysAgo <= numPrevDays; daysAgo++ {
 		go func(tbl *bigtable.Table, ctx context.Context, prefix string, daysAgo int) {
@@ -99,11 +106,11 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 
 			dateStr := start.Format("2006-01-02")
 
-			mu.Lock()
+			muWarmTotalsCache.Lock()
 			// initialize the map for this date in the result set
 			results[dateStr] = map[string]int{"*": 0}
 			// check to see if there is cache data for this date/query
-			if dateCache, ok := warmTotalsCache[dateStr]; ok {
+			if dateCache, ok := warmTotalsCache[dateStr]; ok && useCache(dateStr) {
 				// have a cache for this date
 
 				if val, ok := dateCache[cachePrefix]; ok {
@@ -111,7 +118,7 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 					if daysAgo >= 1 {
 						// only use the cache for yesterday and older
 						results[dateStr] = val
-						mu.Unlock()
+						muWarmTotalsCache.Unlock()
 						intervalsWG.Done()
 						return
 					}
@@ -124,7 +131,7 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 				warmTotalsCache[dateStr] = map[string]map[string]int{}
 				warmTotalsCache[dateStr][cachePrefix] = map[string]int{}
 			}
-			mu.Unlock()
+			muWarmTotalsCache.Unlock()
 
 			var result []bigtable.Row
 			var fetchErr error
@@ -146,12 +153,22 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 				results[dateStr][countBy] = results[dateStr][countBy] + 1
 			}
 
-			// set the result in the cache
-			warmTotalsCache[dateStr][cachePrefix] = results[dateStr]
+			if cacheData, ok := warmTotalsCache[dateStr][cachePrefix]; !ok || len(cacheData) <= 1 {
+				// set the result in the cache
+				muWarmTotalsCache.Lock()
+				warmTotalsCache[dateStr][cachePrefix] = results[dateStr]
+				muWarmTotalsCache.Unlock()
+				cacheNeedsUpdate = true
+			}
+
 		}(tbl, ctx, prefix, daysAgo)
 	}
 
 	intervalsWG.Wait()
+
+	if cacheNeedsUpdate {
+		persistInterfaceToJson(ctx, warmTotalsCacheFilePath, &muWarmTotalsCache, warmTotalsCache)
+	}
 
 	// create a set of all the keys from all dates, to ensure the result objects all have the same keys
 	seenKeySet := map[string]bool{}
@@ -210,12 +227,13 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 	// Set CORS headers for the main request.
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	var numDays, groupBy, forChain, forAddress string
+	var last24Hours, numDays, groupBy, forChain, forAddress string
 
 	// allow GET requests with querystring params, or POST requests with json body.
 	switch r.Method {
 	case http.MethodGet:
 		queryParams := r.URL.Query()
+		last24Hours = queryParams.Get("last24Hours")
 		numDays = queryParams.Get("numDays")
 		groupBy = queryParams.Get("groupBy")
 		forChain = queryParams.Get("forChain")
@@ -232,10 +250,11 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		// declare request body properties
 		var d struct {
-			NumDays    string `json:"numDays"`
-			GroupBy    string `json:"groupBy"`
-			ForChain   string `json:"forChain"`
-			ForAddress string `json:"forAddress"`
+			Last24Hours string `json:"last24Hours"`
+			NumDays     string `json:"numDays"`
+			GroupBy     string `json:"groupBy"`
+			ForChain    string `json:"forChain"`
+			ForAddress  string `json:"forAddress"`
 		}
 
 		// deserialize request body
@@ -250,6 +269,7 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		last24Hours = d.Last24Hours
 		numDays = d.NumDays
 		groupBy = d.GroupBy
 		forChain = d.ForChain
@@ -261,10 +281,11 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var queryDays int
-	if numDays == "" {
-		queryDays = 30
-	} else {
+	// default query period is all time
+	queryDays := int(time.Now().UTC().Sub(releaseDay).Hours() / 24)
+
+	// if the request included numDays, set the query period to that
+	if numDays != "" {
 		var convErr error
 		queryDays, convErr = strconv.Atoi(numDays)
 		if convErr != nil {
@@ -305,39 +326,23 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 
 	// total of last 24 hours
 	var last24HourCount map[string]int
-	wg.Add(1)
-	go func(prefix string, keySegments int) {
-		var err error
-		last24HourInterval := -time.Duration(24) * time.Hour
-		now := time.Now().UTC()
-		start := now.Add(last24HourInterval)
-		defer wg.Done()
-		last24HourCount, err = messageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
-		if err != nil {
-			log.Printf("failed getting count for interval, err: %v", err)
-		}
-	}(prefix, keySegments)
-
-	// total of the last 30 days
-	var periodCount map[string]int
-	wg.Add(1)
-	go func(prefix string, keySegments int) {
-		var err error
-		hours := (24 * queryDays)
-		periodInterval := -time.Duration(hours) * time.Hour
-
-		now := time.Now().UTC()
-		prev := now.Add(periodInterval)
-		start := time.Date(prev.Year(), prev.Month(), prev.Day(), 0, 0, 0, 0, prev.Location())
-
-		defer wg.Done()
-		periodCount, err = messageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
-		if err != nil {
-			log.Fatalf("failed getting count for interval, err: %v", err)
-		}
-	}(prefix, keySegments)
+	if last24Hours != "" {
+		wg.Add(1)
+		go func(prefix string, keySegments int) {
+			var err error
+			last24HourInterval := -time.Duration(24) * time.Hour
+			now := time.Now().UTC()
+			start := now.Add(last24HourInterval)
+			defer wg.Done()
+			last24HourCount, err = messageCountForInterval(tbl, ctx, prefix, start, now, keySegments)
+			if err != nil {
+				log.Printf("failed getting count for interval, err: %v", err)
+			}
+		}(prefix, keySegments)
+	}
 
 	// daily totals
+	periodTotals := map[string]int{}
 	var dailyTotals map[string]map[string]int
 	wg.Add(1)
 	go func(prefix string, keySegments int, queryDays int) {
@@ -347,14 +352,21 @@ func Totals(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Fatalf("failed getting createCountsOfInterval err %v", err)
 		}
+		// sum all the days to create a map with totals for the query period
+		for _, vals := range dailyTotals {
+			for chain, amount := range vals {
+				periodTotals[chain] += amount
+			}
+		}
 	}(prefix, keySegments, queryDays)
 
 	wg.Wait()
 
 	result := &totalsResult{
-		LastDayCount: last24HourCount,
-		TotalCount:   periodCount,
-		DailyTotals:  dailyTotals,
+		LastDayCount:           last24HourCount,
+		TotalCount:             periodTotals,
+		TotalCountDurationDays: queryDays,
+		DailyTotals:            dailyTotals,
 	}
 
 	jsonBytes, err := json.Marshal(result)


### PR DESCRIPTION
Added two functions:
- `/notionaltvl` returns the locked assets per chain, and their notional value at the moment (prices fetched on demand from CoinGecko)
- `/notionaltvlcumulative` returns the locked assets per chain, by day, including what the assets were worth each day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/899)
<!-- Reviewable:end -->
