### PR TITLE
ethereum: make core contract upgradeable

### DIFF
--- a/ethereum/contracts/Implementation.sol
+++ b/ethereum/contracts/Implementation.sol
@@ -30,6 +30,10 @@ contract Implementation is Governance {
         setNextSequence(emitter, sequence + 1);
     }
 
+    function initialize() initializer public virtual {
+        // this function needs to be exposed for an upgrade to pass
+    }
+
     modifier initializer() {
         address implementation = ERC1967Upgrade._getImplementation();
 


### PR DESCRIPTION
The core bridge Implementation contract currently has no `initialize()` method, which means that trying to upgrade to it would revert, since the upgrade logic delegatecalls `initialize`:
https://github.com/certusone/wormhole/blob/60363dd3d1f19ad55d9100f13c58a5c646d02902/ethereum/contracts/Governance.sol#L96-L97

Just adding it here so it's not forgotten the next time we need to do an upgrade.