### PR TITLE
Explorer - fetch stats on first load

### DIFF
--- a/explorer/src/pages/index.tsx
+++ b/explorer/src/pages/index.tsx
@@ -112,7 +112,8 @@ const IndexPage = ({ location }: PageProps) => {
   }
 
   useEffect(() => {
-    statsInterval = setInterval(fetchStats, 30000)
+    fetchStats()  // fetchStats on first load
+    statsInterval = setInterval(fetchStats, 30000) // fetch every 30 seconds
 
     gsap.registerPlugin(ScrollTrigger);
 


### PR DESCRIPTION
Make the request to get stats when the page first loads.
It is currently waiting 30 seconds to make the first request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/925)
<!-- Reviewable:end -->
