### PR TITLE
solitaire: Infer entry point argument type in solitaire! macro

### DIFF
--- a/solana/bridge/cpi_poster/src/lib.rs
+++ b/solana/bridge/cpi_poster/src/lib.rs
@@ -17,5 +17,5 @@ pub use api::{
 };
 
 solitaire! {
-    PostMessage(PostMessageData)                => post_message,
+    PostMessage                => post_message,
 }

--- a/solana/bridge/program/src/lib.rs
+++ b/solana/bridge/program/src/lib.rs
@@ -85,12 +85,12 @@ pub use vaa::{
 };
 
 solitaire! {
-    Initialize(InitializeData)                  => initialize,
-    PostMessage(PostMessageData)                => post_message,
-    PostVAA(PostVAAData)                        => post_vaa,
-    SetFees(SetFeesData)                        => set_fees,
-    TransferFees(TransferFeesData)              => transfer_fees,
-    UpgradeContract(UpgradeContractData)        => upgrade_contract,
-    UpgradeGuardianSet(UpgradeGuardianSetData)  => upgrade_guardian_set,
-    VerifySignatures(VerifySignaturesData)      => verify_signatures,
+    Initialize         => initialize,
+    PostMessage        => post_message,
+    PostVAA            => post_vaa,
+    SetFees            => set_fees,
+    TransferFees       => transfer_fees,
+    UpgradeContract    => upgrade_contract,
+    UpgradeGuardianSet => upgrade_guardian_set,
+    VerifySignatures   => verify_signatures,
 }

--- a/solana/bridge/program_stub/src/lib.rs
+++ b/solana/bridge/program_stub/src/lib.rs
@@ -23,7 +23,7 @@ pub use api::{
 use bridge::PostVAAData;
 
 solitaire! {
-    Initialize(InitializeData)                  => initialize,
-    PostMessage(PostMessageData)                => post_message,
-    PostVAA(PostVAAData)                        => post_vaa,
+    Initialize  => initialize,
+    PostMessage => post_message,
+    PostVAA     => post_vaa,
 }

--- a/solana/migration/src/lib.rs
+++ b/solana/migration/src/lib.rs
@@ -40,9 +40,9 @@ impl From<MigrationError> for SolitaireError {
 }
 
 solitaire! {
-    AddLiquidity(AddLiquidityData) => add_liquidity,
-    RemoveLiquidity(RemoveLiquidityData) => remove_liquidity,
-    ClaimShares(ClaimSharesData) => claim_shares,
-    CreatePool(CreatePoolData) => create_pool,
-    MigrateTokens(MigrateTokensData) => migrate_tokens,
+    AddLiquidity => add_liquidity,
+    RemoveLiquidity => remove_liquidity,
+    ClaimShares => claim_shares,
+    CreatePool => create_pool,
+    MigrateTokens => migrate_tokens,
 }

--- a/solana/modules/nft_bridge/program/src/lib.rs
+++ b/solana/modules/nft_bridge/program/src/lib.rs
@@ -72,12 +72,12 @@ impl From<TokenBridgeError> for SolitaireError {
 }
 
 solitaire! {
-    Initialize(InitializeData) => initialize,
-    CompleteNative(CompleteNativeData) => complete_native,
-    CompleteWrapped(CompleteWrappedData) => complete_wrapped,
-    CompleteWrappedMeta(CompleteWrappedMetaData) => complete_wrapped_meta,
-    TransferWrapped(TransferWrappedData) => transfer_wrapped,
-    TransferNative(TransferNativeData) => transfer_native,
-    RegisterChain(RegisterChainData) => register_chain,
-    UpgradeContract(UpgradeContractData) => upgrade_contract,
+    Initialize          => initialize,
+    CompleteNative      => complete_native,
+    CompleteWrapped     => complete_wrapped,
+    CompleteWrappedMeta => complete_wrapped_meta,
+    TransferWrapped     => transfer_wrapped,
+    TransferNative      => transfer_native,
+    RegisterChain       => register_chain,
+    UpgradeContract     => upgrade_contract,
 }

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -75,13 +75,13 @@ impl From<TokenBridgeError> for SolitaireError {
 }
 
 solitaire! {
-    Initialize(InitializeData) => initialize,
-    AttestToken(AttestTokenData) => attest_token,
-    CompleteNative(CompleteNativeData) => complete_native,
-    CompleteWrapped(CompleteWrappedData) => complete_wrapped,
-    TransferWrapped(TransferWrappedData) => transfer_wrapped,
-    TransferNative(TransferNativeData) => transfer_native,
-    RegisterChain(RegisterChainData) => register_chain,
-    CreateWrapped(CreateWrappedData) => create_wrapped,
-    UpgradeContract(UpgradeContractData) => upgrade_contract,
+    Initialize      => initialize,
+    AttestToken     => attest_token,
+    CompleteNative  => complete_native,
+    CompleteWrapped => complete_wrapped,
+    TransferWrapped => transfer_wrapped,
+    TransferNative  => transfer_native,
+    RegisterChain   => register_chain,
+    CreateWrapped   => create_wrapped,
+    UpgradeContract => upgrade_contract,
 }

--- a/solana/solitaire/program/src/macros.rs
+++ b/solana/solitaire/program/src/macros.rs
@@ -31,7 +31,7 @@ macro_rules! trace_impl {
 /// - A set of client calls scoped to the module `api` that can generate instructions.
 #[macro_export]
 macro_rules! solitaire {
-    { $($row:ident($kind:ty) => $fn:ident),+ $(,)* } => {
+    { $($row:ident => $fn:ident),+ $(,)* } => {
         pub mod instruction {
             use super::*;
             use borsh::{
@@ -66,7 +66,7 @@ macro_rules! solitaire {
 
                     #[inline(never)]
                     pub fn execute<'a, 'b: 'a, 'c>(p: &Pubkey, a: &'c [AccountInfo<'b>], d: &[u8]) -> Result<()> {
-                        let ix_data: $kind = BorshDeserialize::try_from_slice(d).map_err(|e| SolitaireError::InstructionDeserializeFailed(e))?;
+                        let ix_data = BorshDeserialize::try_from_slice(d).map_err(|e| SolitaireError::InstructionDeserializeFailed(e))?;
                         let mut accounts = FromAccounts::from(p, &mut a.iter(), &())?;
                         $fn(&ExecutionContext{program_id: p, accounts: a}, &mut accounts, ix_data)?;
                         Persist::persist(&accounts, p)?;


### PR DESCRIPTION
The type of the `ix_data` binding withing the solitaire! macro expansion
is explicitly annotated with its type, which comes from the macro's
pattern binding `$kind`. However, this type annotation is entirely
optional, since `ix_data` is passed in as an argument to `$fn`, whose
type forecs `ix_data` anyway, and rust will happily infer that from the
application.

I propose we remove it, so the `solitaire!` entry point is easier to use. The syntax is made-up anyway and not particularly intuitive, so I think this is an improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/927)
<!-- Reviewable:end -->
