### PR TITLE
Hardening against governance message spoofing

### DIFF
--- a/node/pkg/vaa/governance.go
+++ b/node/pkg/vaa/governance.go
@@ -4,8 +4,8 @@ import (
 	"time"
 )
 
-var governanceEmitter = Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
-var governanceChain = ChainIDSolana
+var GovernanceEmitter = Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
+var GovernanceChain = ChainIDSolana
 
 func CreateGovernanceVAA(nonce uint32, sequence uint64, guardianSetIndex uint32, payload []byte) *VAA {
 	vaa := &VAA{
@@ -16,8 +16,8 @@ func CreateGovernanceVAA(nonce uint32, sequence uint64, guardianSetIndex uint32,
 		Nonce:            nonce,
 		Sequence:         sequence,
 		ConsistencyLevel: 32,
-		EmitterChain:     governanceChain,
-		EmitterAddress:   governanceEmitter,
+		EmitterChain:     GovernanceChain,
+		EmitterAddress:   GovernanceEmitter,
 		Payload:          payload,
 	}
 


### PR DESCRIPTION
The guardian should never sign messages emitted by the governance emitter coming from a chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/938)
<!-- Reviewable:end -->
