### PR TITLE
bridge_ui: Changed terra est. fees to be more accurate

### DIFF
--- a/bridge_ui/src/hooks/useTransactionFees.tsx
+++ b/bridge_ui/src/hooks/useTransactionFees.tsx
@@ -287,8 +287,8 @@ function EthGasEstimateSummary({
 
 const terraEstimatesByContract = {
   transfer: {
-    lowGasEstimate: BigInt(50000),
-    highGasEstimate: BigInt(150000),
+    lowGasEstimate: BigInt(400000),
+    highGasEstimate: BigInt(700000),
   },
 };
 


### PR DESCRIPTION
I threw together a script that looked at the terra token bridge gas for redeems over the last month:

min  = 3100639
max  = 4506069
mean = 3205947
std  =  204337

Gas prices don't change often (uusd = 0.15 for as long as I can remember and terra.js also hard-codes this as the default)

min UST estimate = 0.15 * 3100639 * 10^-6 = 0.46509585
max UST estimate = 0.15 * 4506069 * 10^-6 = 0.67591035

So let's just make the range 0.4 to 0.7 UST for now?

```import requests
import time
import pandas as pd

gas_data = []
offset = 0
for _ in range(300):
    r = requests.get(f'https://fcd.terra.dev/v1/txs?offset={offset}&limit=100&account=terra10nmmwe8r3g99a9newtqa7a75xfgs2e8z87r2sf')
    data = r.json()
    for tx in data['txs']:
        if tx['tx']['value']['memo'] == 'Wormhole - Complete Transfer':
            gas_data.append((tx['timestamp'], int(tx['gas_used']), int(tx['gas_wanted'])))
    offset = data['next']
    time.sleep(1)

df = pd.DataFrame(gas_data, columns=['timestamp', 'gas_used', 'gas_wanted'])
print('describe\n', df.describe())
print('mean\n', df.mean())
print('std\n', df.std())
print('min\n', df.min())
print('max\n', df.max())

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/987)
<!-- Reviewable:end -->
