### PR TITLE
Bump Solana version to 1.9.4 in Dockerfile.client

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -3,7 +3,7 @@ FROM docker.io/library/rust:1.49@sha256:a50165ea96983c21832578afb1c8c028674c965b
 
 RUN apt-get update && apt-get install -yq libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang ncat
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
-RUN curl -sSfL https://release.solana.com/v1.8.1/install | sh
+RUN curl -sSfL https://release.solana.com/v1.9.4/install | sh
 
 RUN rustup default nightly-2022-01-02
 RUN rustup component add rustfmt


### PR DESCRIPTION
It appears this is needed to get a local devnet working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/989)
<!-- Reviewable:end -->
