### PR TITLE
Implement deposit addresses

### DIFF
--- a/ethereum/contracts/bridge/deposit/Deposit.sol
+++ b/ethereum/contracts/bridge/deposit/Deposit.sol
@@ -1,0 +1,16 @@
+// contracts/deposit/Deposit.sol
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+// This contract is used to drain a deposit address of an ERC20
+contract Deposit {
+    constructor (address token)
+    {
+        SafeERC20.safeTransfer(IERC20(token), msg.sender, IERC20(token).balanceOf(address(this)));
+        selfdestruct(payable(msg.sender));
+    }
+}

--- a/ethereum/contracts/bridge/deposit/DepositETH.sol
+++ b/ethereum/contracts/bridge/deposit/DepositETH.sol
@@ -1,0 +1,15 @@
+// contracts/deposit/Deposit.sol
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+// This contract is used to drain a deposit address of its ETH balance
+contract DepositETH {
+    constructor (address token)
+    {
+        selfdestruct(payable(msg.sender));
+    }
+}


### PR DESCRIPTION
Deposit addresses allow users to initiate cross-chain transfers by sending tokens to an EOA (e.g. to be used to send cross-chain transfers from an exchange). The transfer can then be completed by a "initial-relayer" for the specified fee [there should be an additional fee specified for this in addition to the cross-chain fee].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/993)
<!-- Reviewable:end -->
