### PR TITLE
explorer - less calls to cloud functions

### DIFF
--- a/explorer/src/components/ExplorerStats/ChainOverviewCard.tsx
+++ b/explorer/src/components/ExplorerStats/ChainOverviewCard.tsx
@@ -30,8 +30,8 @@ const ChainOverviewCard: React.FC<ChainOverviewCardProps> = ({
 
     let timeout: NodeJS.Timeout;
     if (
-      totals?.LastDayCount[dataKey] &&
-      totalCount !== totals?.LastDayCount[dataKey]
+      totals?.TotalCount[dataKey] &&
+      totalCount !== totals?.TotalCount[dataKey]
     ) {
       setAnimate(true);
       timeout = setTimeout(() => {
@@ -45,7 +45,6 @@ const ChainOverviewCard: React.FC<ChainOverviewCardProps> = ({
     };
   }, [
     totals?.TotalCount[dataKey],
-    totals?.LastDayCount[dataKey],
     dataKey,
     totalCount,
   ]);

--- a/explorer/src/components/ExplorerStats/ExplorerStats.tsx
+++ b/explorer/src/components/ExplorerStats/ExplorerStats.tsx
@@ -131,7 +131,7 @@ const ExplorerStats: React.FC<StatsProps> = ({
     signal: AbortSignal
   ) => {
     const totalsUrl = `${baseUrl}totals`;
-    let url = `${totalsUrl}?&daily=true&last24Hours=true`
+    let url = `${totalsUrl}?&daily=true`
     if (groupBy) {
       url = `${url}&groupBy=${groupBy}`;
     }
@@ -215,7 +215,7 @@ const ExplorerStats: React.FC<StatsProps> = ({
     signal: AbortSignal
   ) => {
     const transferredUrl = `${baseUrl}notionaltransferred`;
-    let url = `${transferredUrl}?forPeriod=true&numDays=${daysSinceDataStart}`; // ${daysSinceDataStart}`
+    let url = `${transferredUrl}?forPeriod=true&numDays=${daysSinceDataStart}`;
     if (groupBy) {
       url = `${url}&groupBy=${groupBy}`;
     }
@@ -256,7 +256,7 @@ const ExplorerStats: React.FC<StatsProps> = ({
     signal: AbortSignal
   ) => {
     const transferredUrl = `${baseUrl}notionaltransferredto`;
-    let url = `${transferredUrl}?forPeriod=true&daily=true&numDays=${daysSinceDataStart}`; // ${daysSinceDataStart}`
+    let url = `${transferredUrl}?forPeriod=true&daily=true&numDays=${daysSinceDataStart}`;
     if (groupBy) {
       url = `${url}&groupBy=${groupBy}`;
     }
@@ -297,7 +297,7 @@ const ExplorerStats: React.FC<StatsProps> = ({
     signal: AbortSignal
   ) => {
     const transferredToUrl = `${baseUrl}notionaltransferredtocumulative`;
-    let url = `${transferredToUrl}?allTime=true`; // &daily=true&numDays=${daysSinceDataStart}` // TEMP - rm daily=true  //${daysSinceDataStart}`
+    let url = `${transferredToUrl}?allTime=true`
     if (groupBy) {
       url = `${url}&groupBy=${groupBy}`;
     }
@@ -416,14 +416,15 @@ const ExplorerStats: React.FC<StatsProps> = ({
       emitterAddress !== address ||
       emitterChain !== chain
     ) {
+      const newController = new AbortController();
+      setController(newController);
       getData(
         { emitterChain, emitterAddress },
         activeNetwork.endpoints.bigtableFunctionsBase,
-        new AbortController().signal,
+        newController.signal,
         getAllEndpoints
       );
     }
-    controller.abort();
     setTotals(undefined);
     setRecent(undefined);
     setNotionalTransferred(undefined);

--- a/explorer/src/pages/index.tsx
+++ b/explorer/src/pages/index.tsx
@@ -37,7 +37,6 @@ const IndexPage = ({ location }: PageProps) => {
   const [tvl, setTvl] = useState<number | undefined>(undefined)
   const [messageTotal, setMessageTotal] = useState<number | undefined>(undefined)
 
-  let statsInterval: NodeJS.Timer | undefined = undefined
   const controller = new AbortController()
   const { signal } = controller
 
@@ -122,7 +121,6 @@ const IndexPage = ({ location }: PageProps) => {
 
   useEffect(() => {
     fetchStats()  // fetchStats on first load
-    statsInterval = setInterval(fetchStats, 30000) // fetch every 30 seconds
 
     gsap.registerPlugin(ScrollTrigger);
 
@@ -184,10 +182,6 @@ const IndexPage = ({ location }: PageProps) => {
 
 
     return function cleanup() {
-      // clear any ongoing intervals
-      if (statsInterval) {
-        clearInterval(statsInterval);
-      }
       // abort any in-flight requests
       controller.abort();
     }

--- a/explorer/src/pages/index.tsx
+++ b/explorer/src/pages/index.tsx
@@ -262,7 +262,7 @@ const IndexPage = ({ location }: PageProps) => {
                 borderTop: "1px solid white",
               }}
             >
-              <Typography sx={featuredNumber}>7</Typography>
+              <Typography sx={featuredNumber}>8</Typography>
               <Typography variant="body2">chain integrations</Typography>
             </Box>
             {messageTotal && <Box


### PR DESCRIPTION
the polling interval on the index of wormholenetwork.com was 30 seconds, but the function timeout was 60 seconds, so the page could queue up a bunch of requests, causing the cloud functions to scale way up, and become unavailable. This changes removes the polling on the homepage.

This change also removes the polling for some of the /explorer page endpoints. Want to reduce the frequency of calls and see how that effects the functions availability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1019)
<!-- Reviewable:end -->
