### PR TITLE
Never upgrade to an empty guardianSet for Terra

### DIFF
--- a/terra/contracts/wormhole/src/contract.rs
+++ b/terra/contracts/wormhole/src/contract.rs
@@ -261,11 +261,11 @@ fn vaa_update_guardian_set(deps: DepsMut, env: Env, data: &Vec<u8>) -> StdResult
         return ContractError::GuardianSetIndexIncreaseError.std_err();
     }
 
-    /* A new GuardianSet with zero addresses should never be accepted,
+    /* An GuardianSet with no addresses should not be accepted,
      * it would break assumptions of the underlying contracts
      */
-    if new_guardian_set.addresses.len() == 0
-        return ContractError::GuardianSetZeroAddresses.std_err();
+    if new_guardian_set.addresses.is_empty()
+        return ContractError::GuardianSetEmpty.std_err();
     }
 
     let old_guardian_set_index = state.guardian_set_index;

--- a/terra/contracts/wormhole/src/contract.rs
+++ b/terra/contracts/wormhole/src/contract.rs
@@ -264,7 +264,7 @@ fn vaa_update_guardian_set(deps: DepsMut, env: Env, data: &Vec<u8>) -> StdResult
     /* An GuardianSet with no addresses should not be accepted,
      * it would break assumptions of the underlying contracts
      */
-    if new_guardian_set.addresses.is_empty()
+    if new_guardian_set.addresses.is_empty() {
         return ContractError::GuardianSetEmpty.std_err();
     }
 

--- a/terra/contracts/wormhole/src/contract.rs
+++ b/terra/contracts/wormhole/src/contract.rs
@@ -261,6 +261,13 @@ fn vaa_update_guardian_set(deps: DepsMut, env: Env, data: &Vec<u8>) -> StdResult
         return ContractError::GuardianSetIndexIncreaseError.std_err();
     }
 
+    /* A new GuardianSet with zero addresses should never be accepted,
+     * it would break assumptions of the underlying contracts
+     */
+    if new_guardian_set.addresses.len() == 0
+        return ContractError::GuardianSetZeroAddresses.std_err();
+    }
+
     let old_guardian_set_index = state.guardian_set_index;
 
     state.guardian_set_index = new_guardian_set_index;

--- a/terra/contracts/wormhole/src/error.rs
+++ b/terra/contracts/wormhole/src/error.rs
@@ -68,9 +68,9 @@ pub enum ContractError {
     GuardianSetIndexIncreaseError,
 
 
-    /// Guardian set must not be zero
-    #[error("GuardianSetZeroAddresses")]
-    GuardianSetZeroAddresses,
+    /// Guardian set must not be empty
+    #[error("Guardian set must not be empty")]
+    GuardianSetEmpty,
 
     /// VAA was already executed
     #[error("VaaAlreadyExecuted")]

--- a/terra/contracts/wormhole/src/error.rs
+++ b/terra/contracts/wormhole/src/error.rs
@@ -67,6 +67,11 @@ pub enum ContractError {
     #[error("GuardianSetIndexIncreaseError")]
     GuardianSetIndexIncreaseError,
 
+
+    /// Guardian set must not be zero
+    #[error("GuardianSetZeroAddresses")]
+    GuardianSetZeroAddresses,
+
     /// VAA was already executed
     #[error("VaaAlreadyExecuted")]
     VaaAlreadyExecuted,


### PR DESCRIPTION
This is largely just footgun avoidance on terra to make sure we never upload an empty GuardianSet, similar how to we check on EVM.

This PR is incomplete as is, and requires that we write some unit-tests for it to ensure the behavior is as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1033)
<!-- Reviewable:end -->
