### PR TITLE
clients/solana: allow submitting VAAs to mainnet

### DIFF
--- a/clients/solana/package.json
+++ b/clients/solana/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "start": "tsc && node main.js",
+    "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/clients/token_bridge/main.ts
+++ b/clients/token_bridge/main.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 
-const {hideBin} = require('yargs/helpers')
+import { hideBin } from 'yargs/helpers';
 
 import * as elliptic from "elliptic";
 import * as ethers from "ethers";
@@ -9,7 +9,7 @@ import * as web3s from '@solana/web3.js';
 import {fromUint8Array} from "js-base64";
 import {LCDClient, MnemonicKey} from '@terra-money/terra.js';
 import {MsgExecuteContract} from "@terra-money/terra.js";
-import {PublicKey, TransactionInstruction, AccountMeta, Keypair, Connection} from "@solana/web3.js";
+import {PublicKey, TransactionInstruction, Keypair, Connection} from "@solana/web3.js";
 import {base58, solidityKeccak256} from "ethers/lib/utils";
 
 import {setDefaultWasm, importCoreWasm, importTokenWasm, ixFromRust, BridgeImplementation__factory} from '@certusone/wormhole-sdk'


### PR DESCRIPTION
The solana client (core bridge cli) is currently unable to send VAAs to mainnet, because it generates a fresh keypair and requests airdropped funds into it. This PR allows passing in a private key optionally, in which case the airdrop is not requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1066)
<!-- Reviewable:end -->
