### PR TITLE
cloud_functions: Added totalsOnly param to notional-tvl-cumulative

### DIFF
--- a/event_database/cloud_functions/notional-tvl-cumulative.go
+++ b/event_database/cloud_functions/notional-tvl-cumulative.go
@@ -241,10 +241,12 @@ func TvlCumulative(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	var numDays string
+	var totalsOnly string
 	switch r.Method {
 	case http.MethodGet:
 		queryParams := r.URL.Query()
 		numDays = queryParams.Get("numDays")
+		totalsOnly = queryParams.Get("totalsOnly")
 	}
 
 	var queryDays int
@@ -311,12 +313,15 @@ func TvlCumulative(w http.ResponseWriter, r *http.Request) {
 				}
 
 				asset.Notional = roundToTwoDecimalPlaces(notional)
-				// create a new LockAsset in order to exclude TokenPrice and Amount
-				dailyTvl[date][chain][symbol] = LockedAsset{
-					Symbol:      asset.Symbol,
-					Address:     asset.Address,
-					CoinGeckoId: asset.CoinGeckoId,
-					Notional:    asset.Notional,
+
+				if totalsOnly == "" {
+					// create a new LockAsset in order to exclude TokenPrice and Amount
+					dailyTvl[date][chain][symbol] = LockedAsset{
+						Symbol:      asset.Symbol,
+						Address:     asset.Address,
+						CoinGeckoId: asset.CoinGeckoId,
+						Notional:    asset.Notional,
+					}
 				}
 
 				// add this asset's notional to the date/chain/*


### PR DESCRIPTION
Consumers may only care about the totals which results in a drastically
smaller response payload size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1075)
<!-- Reviewable:end -->
