### PR TITLE
solitaire: fix initialisation check

### DIFF
--- a/solana/solitaire/program/src/types/accounts.rs
+++ b/solana/solitaire/program/src/types/accounts.rs
@@ -107,10 +107,10 @@ impl<'r, T: Owned + Default, const IsInitialized: AccountState> DerefMut
     }
 }
 
-impl<'r, T: Owned + Default, const IsInitialized: AccountState> Data<'r, T, IsInitialized> {
+impl<'r, T: Owned + Default> Data<'r, T, { AccountState::MaybeInitialized }> {
     /// Is the account already initialized / created
     pub fn is_initialized(&self) -> bool {
-        **self.0.lamports.borrow() != 0
+        !self.0.data.borrow().is_empty()
     }
 }
 


### PR DESCRIPTION
We consider an account to be initialised when it has data stored in it. It also doesn't make too much sense to call `is_initialized` on `Unitialized` or `Initialized` accounts, since the status of these is statically known.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1099)
<!-- Reviewable:end -->
