### PR TITLE
cloud_functions: Split notional-tvl into read and write (to cache) entry points

### DIFF
--- a/event_database/functions_server/main.go
+++ b/event_database/functions_server/main.go
@@ -60,6 +60,7 @@ func newMux() *http.ServeMux {
 	mux.HandleFunc("/notionaltransferredto", p.NotionalTransferredTo)
 	mux.HandleFunc("/notionaltransferredtocumulative", p.NotionalTransferredToCumulative)
 	mux.HandleFunc("/notionaltvl", p.TVL)
+	mux.HandleFunc("/computenotionaltvl", p.ComputeTVL)
 	mux.HandleFunc("/notionaltvlcumulative", p.TvlCumulative)
 	mux.HandleFunc("/addressestransferredto", p.AddressesTransferredTo)
 	mux.HandleFunc("/addressestransferredtocumulative", p.AddressesTransferredToCumulative)


### PR DESCRIPTION
ComputeTVL is intended to be called periodically which writes the computed result to notional-tvl.json. TVL reads from notional-tvl.json and returns it as the response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1110)
<!-- Reviewable:end -->
