### PR TITLE
guardian - generate auth proof for shutdown voting

### DIFF
--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -1,17 +1,19 @@
 package guardiand
 
 import (
+	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
 	"github.com/btcsuite/btcutil/bech32"
 	"github.com/certusone/wormhole/node/pkg/vaa"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mr-tron/base58"
 	"github.com/spf13/pflag"
 	"github.com/tendermint/tendermint/libs/rand"
-	"log"
-	"strconv"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
@@ -26,6 +28,8 @@ var templateGuardianIndex *int
 var chainID *string
 var address *string
 var module *string
+var shutdownGuardianKey *string
+var shutdownPubKey *string
 
 func init() {
 	governanceFlagSet := pflag.NewFlagSet("governance", pflag.ExitOnError)
@@ -34,6 +38,10 @@ func init() {
 
 	moduleFlagSet := pflag.NewFlagSet("module", pflag.ExitOnError)
 	module = moduleFlagSet.String("module", "", "Module name")
+
+	authProofFlagSet := pflag.NewFlagSet("auth-proof", pflag.ExitOnError)
+	shutdownGuardianKey = authProofFlagSet.String("guardian-key", "", "Guardian key to sign proof. File path or hex string")
+	shutdownPubKey = authProofFlagSet.String("proof-pub-key", "", "Public key to encode in proof")
 
 	templateGuardianIndex = TemplateCmd.PersistentFlags().Int("idx", 1, "Default current guardian set index")
 
@@ -50,6 +58,9 @@ func init() {
 	AdminClientTokenBridgeUpgradeContractCmd.Flags().AddFlagSet(governanceFlagSet)
 	AdminClientTokenBridgeUpgradeContractCmd.Flags().AddFlagSet(moduleFlagSet)
 	TemplateCmd.AddCommand(AdminClientTokenBridgeUpgradeContractCmd)
+
+	AdminClientShutdownProofCmd.Flags().AddFlagSet(authProofFlagSet)
+	TemplateCmd.AddCommand(AdminClientShutdownProofCmd)
 }
 
 var TemplateCmd = &cobra.Command{
@@ -79,6 +90,11 @@ var AdminClientTokenBridgeUpgradeContractCmd = &cobra.Command{
 	Use:   "token-bridge-upgrade-contract",
 	Short: "Generate an empty token bridge contract upgrade template at specified path",
 	Run:   runTokenBridgeUpgradeContractTemplate,
+}
+var AdminClientShutdownProofCmd = &cobra.Command{
+	Use:   "shutdown-proof",
+	Short: "Generate an auth proof for shutdown voting on behalf of the guardian.",
+	Run:   runShutdownProofTemplate,
 }
 
 func runGuardianSetTemplate(cmd *cobra.Command, args []string) {
@@ -210,6 +226,51 @@ func runTokenBridgeUpgradeContractTemplate(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 	fmt.Print(string(b))
+}
+
+func runShutdownProofTemplate(cmd *cobra.Command, args []string) {
+	// ensure values were passed
+	if *shutdownPubKey == "" {
+		log.Fatal("--proof-pub-key cannot be blank.")
+	}
+	if *shutdownGuardianKey == "" {
+		log.Fatal("--guardian-key cannot be blank.")
+	}
+
+	// load the guardian key that will sign the proof
+	var guardianKey *ecdsa.PrivateKey
+	var keyErr error
+	// check if the key is a hex string
+	_, hexDecodeErr := hex.DecodeString(*shutdownGuardianKey)
+	if hexDecodeErr == nil {
+		guardianKey, keyErr = crypto.HexToECDSA(*shutdownGuardianKey)
+	} else {
+		// the supplied guardian key is not hex, must be a file path to load
+		guardianKey, keyErr = loadGuardianKey(*shutdownGuardianKey)
+	}
+	if keyErr != nil {
+		log.Fatal("failed fetching guardian key.", keyErr)
+	}
+
+	// create the payload of the proof
+	pubKey := common.HexToAddress(*shutdownPubKey)
+	digest := crypto.Keccak256Hash(pubKey.Bytes())
+
+	// sign the payload of the proof
+	ethProof, err := crypto.Sign(digest.Bytes(), guardianKey)
+	if err != nil {
+		log.Fatal("failed creating proof.", err)
+	}
+
+	// log the public key in the proof and the public key that signed the proof
+	fmt.Printf(
+		"The following proof will allow public key \"%v\" to vote on behalf of guardian \"%v\":\n",
+		pubKey.Hex(),
+		crypto.PubkeyToAddress(guardianKey.PublicKey),
+	)
+
+	proofHex := hex.EncodeToString(ethProof)
+	fmt.Print(proofHex)
 }
 
 // parseAddress parses either a hex-encoded address and returns


### PR DESCRIPTION
Adds auth proof generation for shutdown voting to the Guardian's `template` CLI.

Designed this to work with an armored key file (as is supplied to `guardiand`), and a hex string key (for integration testing/devnet scripting).

```bash
go run main.go template shutdown-proof --guardian-key=/guardian/key/file/path/secret.key --proof-pub-key=0x-public-key-to-encode-in-proof
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1113)
<!-- Reviewable:end -->
