### PR TITLE
cloud_functions: notional-tvl-cumulative optimizations

### DIFF
--- a/event_database/functions_server/main.go
+++ b/event_database/functions_server/main.go
@@ -62,6 +62,7 @@ func newMux() *http.ServeMux {
 	mux.HandleFunc("/notionaltvl", p.TVL)
 	mux.HandleFunc("/computenotionaltvl", p.ComputeTVL)
 	mux.HandleFunc("/notionaltvlcumulative", p.TvlCumulative)
+	mux.HandleFunc("/computenotionaltvlcumulative", p.ComputeTvlCumulative)
 	mux.HandleFunc("/addressestransferredto", p.AddressesTransferredTo)
 	mux.HandleFunc("/addressestransferredtocumulative", p.AddressesTransferredToCumulative)
 	mux.HandleFunc("/totals", p.Totals)


### PR DESCRIPTION
Added two entry points: ComputeTvlCumulative and TvlCumulative.
The first computes the result and writes it to the results cache -
intended to be invoked periodically by a scheduled task.
The second reads from the results cache and returns it as the response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1118)
<!-- Reviewable:end -->
