### PR TITLE
node/pkg/ethereum: move up nil check for TransactionReceipt

### DIFF
--- a/node/pkg/ethereum/watcher.go
+++ b/node/pkg/ethereum/watcher.go
@@ -130,7 +130,7 @@ func NewEthWatcher(
 	unsafeDevMode bool) *Watcher {
 
 	var ethIntf common.Ethish
-	if chainID == vaa.ChainIDCelo && ! unsafeDevMode {
+	if chainID == vaa.ChainIDCelo && !unsafeDevMode {
 		// When we are running in mainnet or testnet, we need to use the Celo ethereum library rather than go-ethereum.
 		// However, in devnet, we currently run the standard ETH node for Celo, so we need to use the standard go-ethereum.
 		ethIntf = &celo.CeloImpl{NetworkName: networkName}
@@ -443,24 +443,6 @@ func (e *Watcher) Run(ctx context.Context) error {
 						tx, err := e.ethIntf.TransactionReceipt(timeout, pLock.message.TxHash)
 						cancel()
 
-						// This should never happen - if we got this far, it means that logs were emitted,
-						// which is only possible if the transaction succeeded. We check it anyway just
-						// in case the EVM implementation is buggy.
-						if tx.Status != 1 {
-							logger.Error("transaction receipt with non-success status",
-								zap.Stringer("tx", pLock.message.TxHash),
-								zap.Stringer("blockhash", key.BlockHash),
-								zap.Stringer("emitter_address", key.EmitterAddress),
-								zap.Uint64("sequence", key.Sequence),
-								zap.Stringer("current_block", ev.Number),
-								zap.Stringer("current_blockhash", currentHash),
-								zap.String("eth_network", e.networkName),
-								zap.Error(err))
-							delete(e.pending, key)
-							ethMessagesOrphaned.WithLabelValues(e.networkName, "tx_failed").Inc()
-							continue
-						}
-
 						// If the node returns an error after waiting expectedConfirmation blocks,
 						// it means the chain reorged and the transaction was orphaned. The
 						// TransactionReceipt call is using the same websocket connection than the
@@ -481,6 +463,24 @@ func (e *Watcher) Run(ctx context.Context) error {
 								zap.Error(err))
 							delete(e.pending, key)
 							ethMessagesOrphaned.WithLabelValues(e.networkName, "not_found").Inc()
+							continue
+						}
+
+						// This should never happen - if we got this far, it means that logs were emitted,
+						// which is only possible if the transaction succeeded. We check it anyway just
+						// in case the EVM implementation is buggy.
+						if tx.Status != 1 {
+							logger.Error("transaction receipt with non-success status",
+								zap.Stringer("tx", pLock.message.TxHash),
+								zap.Stringer("blockhash", key.BlockHash),
+								zap.Stringer("emitter_address", key.EmitterAddress),
+								zap.Uint64("sequence", key.Sequence),
+								zap.Stringer("current_block", ev.Number),
+								zap.Stringer("current_blockhash", currentHash),
+								zap.String("eth_network", e.networkName),
+								zap.Error(err))
+							delete(e.pending, key)
+							ethMessagesOrphaned.WithLabelValues(e.networkName, "tx_failed").Inc()
 							continue
 						}
 


### PR DESCRIPTION
This fixes a null pointer dereference for a nil tx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1151)
<!-- Reviewable:end -->
