### PR TITLE
repair_eth: work better when messages are skipped

### DIFF
--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -308,8 +308,8 @@ func main() {
 			log.Fatalf("failed to run find FindMissingMessages RPC: %v", err)
 		}
 
-		msgs := make([]*db.VAAID, len(resp.MissingMessages))
-		for i, id := range resp.MissingMessages {
+		msgs := []*db.VAAID{}
+		for _, id := range resp.MissingMessages {
 			fmt.Println(id)
 			vId, err := db.VaaIDFromString(id)
 			if err != nil {
@@ -317,10 +317,9 @@ func main() {
 			}
 			if *vId == polygonIgnoredVaa {
 				log.Printf("Ignored message: %+v", &polygonIgnoredVaa)
-				msgs = append(msgs[:i], msgs[i+1:]...)
 				continue
 			}
-			msgs[i] = vId
+			msgs = append(msgs, vId)
 		}
 
 		if len(msgs) == 0 {


### PR DESCRIPTION
Otherwise there can be a nil pointer deref for polygon when it skips the message we want to ignore.

This sets the messages to a variable sized slice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1163)
<!-- Reviewable:end -->
