### PR TITLE
cloud_functions: don't add today's totals to warm cache

### DIFF
--- a/event_database/cloud_functions/totals.go
+++ b/event_database/cloud_functions/totals.go
@@ -122,14 +122,7 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 						intervalsWG.Done()
 						return
 					}
-				} else {
-					// no cache for this query
-					warmTotalsCache[dateStr][cachePrefix] = map[string]int{}
 				}
-			} else {
-				// no cache for this date, initialize the map
-				warmTotalsCache[dateStr] = map[string]map[string]int{}
-				warmTotalsCache[dateStr][cachePrefix] = map[string]int{}
 			}
 			muWarmTotalsCache.Unlock()
 
@@ -155,7 +148,13 @@ func createCountsOfInterval(tbl *bigtable.Table, ctx context.Context, prefix str
 
 			if daysAgo >= 1 {
 				muWarmTotalsCache.Lock()
-				if cacheData, ok := warmTotalsCache[dateStr][cachePrefix]; !ok || len(cacheData) <= 1 || !useCache(dateStr) {
+				if _, ok := warmTotalsCache[dateStr]; !ok {
+					warmTotalsCache[dateStr] = map[string]map[string]int{}
+				}
+				if _, ok := warmTotalsCache[dateStr][cachePrefix]; !ok {
+					warmTotalsCache[dateStr][cachePrefix] = map[string]int{}
+				}
+				if len(warmTotalsCache[dateStr][cachePrefix]) <= 1 || !useCache(dateStr) {
 					// set the result in the cache
 					warmTotalsCache[dateStr][cachePrefix] = results[dateStr]
 					cacheNeedsUpdate = true


### PR DESCRIPTION
Don't add today's totals to the warm cache, otherwise incomplete totals may
exist for today's date in the cache tomorrow. Only adding the totals to the
warm cache for yesterday or older fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1184)
<!-- Reviewable:end -->
