### PR TITLE
adding changes to support abi method selector

### DIFF
--- a/algorand/admin.py
+++ b/algorand/admin.py
@@ -1010,7 +1010,7 @@ class PortalCore:
                     sender=sender.getAddress(),
                     index=int.from_bytes(bytes.fromhex(p["ToAddress"]), "big"),
                     on_complete=transaction.OnComplete.NoOpOC,
-                    app_args=[b"completeTransfer", vaa],
+                    app_args=[bytes.fromhex("903f4535"), vaa],
                     foreign_assets = foreign_assets,
                     sp=sp
                 ))

--- a/algorand/test/test.py
+++ b/algorand/test/test.py
@@ -134,10 +134,13 @@ class AlgoTest(PortalCore):
         while True:
             nexttoken = ""
             while True:
-                response = self.myindexer.search_transactions( min_round=self.INDEXER_ROUND, note_prefix=self.NOTE_PREFIX, next_page=nexttoken)
+                response = self.myindexer.search_transactions( min_round=self.INDEXER_ROUND, next_page=nexttoken)
 #                pprint.pprint(response)
                 for x in response["transactions"]:
 #                    pprint.pprint(x)
+                    if 'inner-txns' not in x:
+                        continue
+
                     for y in x["inner-txns"]:
                         if "application-transaction" not in y:
                             continue

--- a/algorand/test_contract.py
+++ b/algorand/test_contract.py
@@ -21,7 +21,7 @@ from typing import List, Tuple, Dict, Any, Optional, Union
 from pyteal.ast import *
 from pyteal.types import *
 from pyteal.compiler import *
-from pyteal.ir import *
+from pyteal.ir import  *
 from globals import *
 from inlineasm import *
 
@@ -134,7 +134,7 @@ def approve_app():
         [METHOD == Bytes("test1"), test1()],
         [METHOD == Bytes("setup"), setup()],
         [METHOD == Bytes("mint"), mint()],
-        [METHOD == Bytes("completeTransfer"), completeTransfer()],
+        [METHOD == Bytes("base16", "0x903f4535"), completeTransfer()],
     )
 
     on_create = Seq( [

--- a/algorand/token_bridge.py
+++ b/algorand/token_bridge.py
@@ -522,7 +522,7 @@ def approve_token_bridge(seed_amt: int, tmpl_sig: TmplSig, devMode: bool):
                     tidx.store(Txn.group_index() + Int(1)),
                     MagicAssert(And(
                         Gtxn[tidx.load()].type_enum() == TxnType.ApplicationCall,
-                        Gtxn[tidx.load()].application_args[0] == Txn.application_args[0],
+                        Gtxn[tidx.load()].application_args[0] == Bytes("base16", "0x903f4535"), # sha256("portal_transfer(byte[])byte[]")[:4]
                         Gtxn[tidx.load()].application_args[1] == Txn.application_args[1],
                         Gtxn[tidx.load()].application_id() == aid.load()
                     )),

--- a/sdk/js/src/algorand/Algorand.ts
+++ b/sdk/js/src/algorand/Algorand.ts
@@ -873,7 +873,8 @@ export async function _submitVAAAlgorand(
 
       txs.push({
         tx: makeApplicationCallTxnFromObject({
-          appArgs: [textToUint8Array("completeTransfer"), vaa],
+          // 0x903f4535 is sha256("portal_transfer(byte[])byte[]").slice(0,4)
+          appArgs: [Buffer.from("903f4535", "hex"), vaa],
           appIndex: aid,
           foreignAssets: foreignAssets,
           from: senderAddr,


### PR DESCRIPTION
This change should allow ABI method selector routing according to ARC4

https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md

The method signature is `portal_transfer(byte[])byte[]` where the first and only argument is the VAA and byte array is returned though it may be empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1186)
<!-- Reviewable:end -->
