### PR TITLE
Algo/abi:  adding changes to support abi method selector

### DIFF
--- a/algorand/admin.py
+++ b/algorand/admin.py
@@ -21,7 +21,7 @@ from gentest import GenTest
 
 from algosdk.v2client.algod import AlgodClient
 from algosdk.kmd import KMDClient
-from algosdk import account, mnemonic
+from algosdk import account, mnemonic, abi
 from algosdk.encoding import decode_address, encode_address
 from algosdk.future import transaction
 from pyteal import compileTeal, Mode, Expr
@@ -1006,11 +1006,12 @@ class PortalCore:
                 txns[-1].fee = txns[-1].fee * 2
 
             if p["Meta"] == "TokenBridge Transfer With Payload":
+                m = abi.Method("portal_transfer", [abi.Argument("byte[]")], abi.Returns("byte[]"))
                 txns.append(transaction.ApplicationCallTxn(
                     sender=sender.getAddress(),
                     index=int.from_bytes(bytes.fromhex(p["ToAddress"]), "big"),
                     on_complete=transaction.OnComplete.NoOpOC,
-                    app_args=[b"completeTransfer", vaa],
+                    app_args=[m.get_selector(), m.args[0].type.encode(vaa)],
                     foreign_assets = foreign_assets,
                     sp=sp
                 ))

--- a/algorand/test/test.py
+++ b/algorand/test/test.py
@@ -134,10 +134,13 @@ class AlgoTest(PortalCore):
         while True:
             nexttoken = ""
             while True:
-                response = self.myindexer.search_transactions( min_round=self.INDEXER_ROUND, note_prefix=self.NOTE_PREFIX, next_page=nexttoken)
+                response = self.myindexer.search_transactions( min_round=self.INDEXER_ROUND, next_page=nexttoken)
 #                pprint.pprint(response)
                 for x in response["transactions"]:
 #                    pprint.pprint(x)
+                    if 'inner-txns' not in x:
+                        continue
+
                     for y in x["inner-txns"]:
                         if "application-transaction" not in y:
                             continue

--- a/algorand/test_contract.py
+++ b/algorand/test_contract.py
@@ -21,7 +21,7 @@ from typing import List, Tuple, Dict, Any, Optional, Union
 from pyteal.ast import *
 from pyteal.types import *
 from pyteal.compiler import *
-from pyteal.ir import *
+from pyteal.ir import  *
 from globals import *
 from inlineasm import *
 
@@ -32,6 +32,8 @@ from TmplSig import TmplSig
 from local_blob import LocalBlob
 
 import sys
+
+portal_transfer_selector = MethodSignature("portal_transfer(byte[])byte[]")
 
 def fullyCompileContract(client: AlgodClient, contract: Expr) -> bytes:
     teal = compileTeal(contract, mode=Mode.Application, version=6)
@@ -104,7 +106,7 @@ def approve_app():
         off = ScratchVar()
 
         return Seq([
-            off.store(Btoi(Extract(Txn.application_args[1], Int(5), Int(1))) * Int(66) + Int(190)), 
+            off.store(Btoi(Extract(Txn.application_args[1], Int(7), Int(1))) * Int(66) + Int(192)), 
             Log(Extract(Txn.application_args[1], off.load(), Len(Txn.application_args[1]) - off.load())),
             Approve()
         ])
@@ -134,7 +136,7 @@ def approve_app():
         [METHOD == Bytes("test1"), test1()],
         [METHOD == Bytes("setup"), setup()],
         [METHOD == Bytes("mint"), mint()],
-        [METHOD == Bytes("completeTransfer"), completeTransfer()],
+        [METHOD == portal_transfer_selector, completeTransfer()],
     )
 
     on_create = Seq( [

--- a/algorand/token_bridge.py
+++ b/algorand/token_bridge.py
@@ -40,6 +40,8 @@ bits_per_key = max_bytes_per_key * bits_per_byte
 max_bytes = max_bytes_per_key * max_keys
 max_bits = bits_per_byte * max_bytes
 
+portal_transfer_selector = MethodSignature("portal_transfer(byte[])byte[]")
+
 def fullyCompileContract(genTeal, client: AlgodClient, contract: Expr, name, devmode) -> bytes:
     if devmode:
         teal = compileTeal(contract, mode=Mode.Application, version=6, assembleConstants=True)
@@ -522,8 +524,8 @@ def approve_token_bridge(seed_amt: int, tmpl_sig: TmplSig, devMode: bool):
                     tidx.store(Txn.group_index() + Int(1)),
                     MagicAssert(And(
                         Gtxn[tidx.load()].type_enum() == TxnType.ApplicationCall,
-                        Gtxn[tidx.load()].application_args[0] == Txn.application_args[0],
-                        Gtxn[tidx.load()].application_args[1] == Txn.application_args[1],
+                        Gtxn[tidx.load()].application_args[0] == portal_transfer_selector, # sha256("portal_transfer(byte[])byte[]")[:4]
+                        Gtxn[tidx.load()].application_args[1] == Concat(Extract(Itob(Len(Txn.application_args[1])), Int(6), Int(2)), Txn.application_args[1]),
                         Gtxn[tidx.load()].application_id() == aid.load()
                     )),
                     Destination.store(getAppAddress(aid.load()))

--- a/sdk/js/src/algorand/Algorand.ts
+++ b/sdk/js/src/algorand/Algorand.ts
@@ -15,6 +15,9 @@ import algosdk, {
   signLogicSigTransaction,
   Transaction,
 } from "algosdk";
+
+import abi from "algosdk";
+
 import { BigNumber } from "ethers";
 import { keccak256 } from "ethers/lib/utils";
 import { getEmitterAddressAlgorand } from "../bridge";
@@ -871,9 +874,11 @@ export async function _submitVAAAlgorand(
     if (meta === "TokenBridge Transfer With Payload") {
       txs[txs.length - 1].tx.appForeignApps = [aid];
 
+      let m = abi.ABIMethod.fromSignature("portal_transfer(byte[])byte[]");
+      
       txs.push({
         tx: makeApplicationCallTxnFromObject({
-          appArgs: [textToUint8Array("completeTransfer"), vaa],
+          appArgs: [m.getSelector(), (m.args[0].type as abi.ABIType).encode(vaa)],
           appIndex: aid,
           foreignAssets: foreignAssets,
           from: senderAddr,


### PR DESCRIPTION

algorand has a newer standard : https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md

The change here is to make the called payload3 contract follow the newer standard so that the pyteal/stub stuff just "does the right thing"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1187)
<!-- Reviewable:end -->
