### PR TITLE
Ensure that we return if we fail to store the VAA in handleObservation

### DIFF
--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -233,6 +233,7 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 
 			if err := p.db.StoreSignedVAA(signed); err != nil {
 				p.logger.Error("failed to store signed VAA", zap.Error(err))
+				return
 			}
 
 			p.broadcastSignedVAA(signed)


### PR DESCRIPTION
If we fail to store the signedVAA in the DB, we shouldn't continue further, right?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1207)
<!-- Reviewable:end -->
