### PR TITLE
Solana fix warnings

### DIFF
--- a/solana/bridge/client/src/main.rs
+++ b/solana/bridge/client/src/main.rs
@@ -1,6 +1,5 @@
-
+#![allow(incomplete_features)]
 #![feature(adt_const_params)]
-#![allow(warnings)]
 
 use std::{
     fmt::Display,
@@ -9,12 +8,10 @@ use std::{
 };
 
 use borsh::BorshDeserialize;
-use bridge::{
-    accounts::{
-        Bridge,
-        BridgeData,
-        FeeCollector,
-    },
+use bridge::accounts::{
+    Bridge,
+    BridgeData,
+    FeeCollector,
 };
 use clap::{
     crate_description,
@@ -26,7 +23,6 @@ use clap::{
     Arg,
     SubCommand,
 };
-use hex;
 use solana_clap_utils::{
     input_parsers::{
         keypair_of,
@@ -50,7 +46,6 @@ use solana_sdk::{
         CommitmentLevel,
     },
     native_token::*,
-    program_error::ProgramError::AccountAlreadyInitialized,
     pubkey::Pubkey,
     signature::{
         read_keypair_file,
@@ -77,6 +72,10 @@ struct Config {
 type Error = Box<dyn std::error::Error>;
 type CommmandResult = Result<Option<Transaction>, Error>;
 
+// [`get_recent_blockhash`] is deprecated, but devnet deployment hangs using the
+// recommended method, so allowing deprecated here. This is only the client, so
+// no risk.
+#[allow(deprecated)]
 fn command_deploy_bridge(
     config: &Config,
     bridge: &Pubkey,
@@ -98,18 +97,22 @@ fn command_deploy_bridge(
         initial_guardians.as_slice(),
     )
     .unwrap();
-    println!("config account: {}, ", ix.accounts[0].pubkey.to_string());
+    println!("config account: {}, ", ix.accounts[0].pubkey);
     let mut transaction = Transaction::new_with_payer(&[ix], Some(&config.fee_payer.pubkey()));
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(
         config,
-        minimum_balance_for_rent_exemption + fee_calculator.calculate_fee(&transaction.message()),
+        minimum_balance_for_rent_exemption + fee_calculator.calculate_fee(transaction.message()),
     )?;
     transaction.sign(&[&config.fee_payer, &config.owner], recent_blockhash);
     Ok(Some(transaction))
 }
 
+// [`get_recent_blockhash`] is deprecated, but devnet deployment hangs using the
+// recommended method, so allowing deprecated here. This is only the client, so
+// no risk.
+#[allow(deprecated)]
 fn command_post_message(
     config: &Config,
     bridge: &Pubkey,
@@ -164,7 +167,7 @@ fn command_post_message(
         Transaction::new_with_payer(&[transfer_ix, ix], Some(&config.fee_payer.pubkey()));
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
     transaction.sign(
         &[&config.fee_payer, &config.owner, &message],
         recent_blockhash,
@@ -186,7 +189,7 @@ fn main() {
                 .global(true)
                 .help("Configuration file to use");
             if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
-                arg.default_value(&config_file)
+                arg.default_value(config_file)
             } else {
                 arg
             }
@@ -360,10 +363,9 @@ fn main() {
         ("create-bridge", Some(arg_matches)) => {
             let bridge = pubkey_of(arg_matches, "bridge").unwrap();
             let initial_guardians = values_of::<String>(arg_matches, "guardian").unwrap();
-            let initial_data: Vec<Vec<u8>> = initial_guardians
+            let initial_data = initial_guardians
                 .into_iter()
-                .map(|key| hex::decode(key).unwrap())
-                .collect::<Vec<Vec<u8>>>();
+                .map(|key| hex::decode(key).unwrap());
             let guardians: Vec<[u8; 20]> = initial_data
                 .into_iter()
                 .map(|key| {

--- a/solana/bridge/cpi_poster/src/instructions.rs
+++ b/solana/bridge/cpi_poster/src/instructions.rs
@@ -7,6 +7,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn post_message(
     program_id: Pubkey,
     bridge_id: Pubkey,

--- a/solana/bridge/program/src/accounts/posted_message.rs
+++ b/solana/bridge/program/src/accounts/posted_message.rs
@@ -26,6 +26,7 @@ pub type PostedMessage<'a, const State: AccountState> = Data<'a, PostedMessageDa
 // This is using the same payload as the PostedVAA for backwards compatibility.
 // This will be deprecated in a future release.
 #[repr(transparent)]
+#[derive(Default)]
 pub struct PostedMessageData(pub MessageData);
 
 #[derive(Debug, Default, BorshSerialize, BorshDeserialize, Clone, Serialize, Deserialize)]
@@ -63,7 +64,7 @@ pub struct MessageData {
 
 impl BorshSerialize for PostedMessageData {
     fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writer.write(b"msg")?;
+        writer.write_all(b"msg")?;
         BorshSerialize::serialize(&self.0, writer)
     }
 }
@@ -88,12 +89,6 @@ impl Deref for PostedMessageData {
 impl DerefMut for PostedMessageData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { std::mem::transmute(&mut self.0) }
-    }
-}
-
-impl Default for PostedMessageData {
-    fn default() -> Self {
-        PostedMessageData(MessageData::default())
     }
 }
 

--- a/solana/bridge/program/src/accounts/posted_vaa.rs
+++ b/solana/bridge/program/src/accounts/posted_vaa.rs
@@ -31,11 +31,12 @@ impl<'a, const State: AccountState> Seeded<&PostedVAADerivationData> for PostedV
 }
 
 #[repr(transparent)]
+#[derive(Default)]
 pub struct PostedVAAData(pub MessageData);
 
 impl BorshSerialize for PostedVAAData {
     fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writer.write(b"vaa")?;
+        writer.write_all(b"vaa")?;
         BorshSerialize::serialize(&self.0, writer)
     }
 }
@@ -60,12 +61,6 @@ impl Deref for PostedVAAData {
 impl DerefMut for PostedVAAData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { std::mem::transmute(&mut self.0) }
-    }
-}
-
-impl Default for PostedVAAData {
-    fn default() -> Self {
-        PostedVAAData(MessageData::default())
     }
 }
 

--- a/solana/bridge/program/src/api/governance.rs
+++ b/solana/bridge/program/src/api/governance.rs
@@ -1,9 +1,7 @@
 use solitaire::*;
 
 use solana_program::{
-    log::sol_log,
     program::invoke_signed,
-    program_error::ProgramError,
     pubkey::Pubkey,
     sysvar::{
         clock::Clock,

--- a/solana/bridge/program/src/api/governance.rs
+++ b/solana/bridge/program/src/api/governance.rs
@@ -36,7 +36,7 @@ use crate::{
     CHAIN_ID_SOLANA,
 };
 
-fn verify_governance<'a, T>(vaa: &ClaimableVAA<'a, T>) -> Result<()>
+fn verify_governance<T>(vaa: &ClaimableVAA<T>) -> Result<()>
 where
     T: DeserializePayload,
 {

--- a/solana/bridge/program/src/api/post_vaa.rs
+++ b/solana/bridge/program/src/api/post_vaa.rs
@@ -34,10 +34,7 @@ use serde::{
     Serialize,
 };
 use sha3::Digest;
-use solana_program::{
-    program_error::ProgramError,
-    pubkey::Pubkey,
-};
+use solana_program::program_error::ProgramError;
 use solitaire::{
     processors::seeded::Seeded,
     CreationLamports::Exempt,

--- a/solana/bridge/program/src/api/post_vaa.rs
+++ b/solana/bridge/program/src/api/post_vaa.rs
@@ -176,7 +176,7 @@ fn check_active<'r>(
 }
 
 // Static list of invalid signature accounts that are not allowed to post VAAs.
-static INVALID_SIGNATURES: &'static [&'static str; 16] = &[
+static INVALID_SIGNATURES: &[&str; 16] = &[
     "18eK1799CaNMGCUnnCt1Kq2uwKkax6T2WmtrDsZuVFQ",
     "2g6NCUUPaD6AxdHPQMVLpjpAvBfKMek6dDiGUe2A6T33",
     "3hYV5968hNzbqUfcvnQ6v9D5h32hEwGJn19c47N3unNj",
@@ -224,10 +224,10 @@ fn check_integrity<'r>(
         v.write_u32::<BigEndian>(vaa.timestamp)?;
         v.write_u32::<BigEndian>(vaa.nonce)?;
         v.write_u16::<BigEndian>(vaa.emitter_chain)?;
-        v.write(&vaa.emitter_address)?;
+        v.write_all(&vaa.emitter_address)?;
         v.write_u64::<BigEndian>(vaa.sequence)?;
         v.write_u8(vaa.consistency_level)?;
-        v.write(&vaa.payload)?;
+        v.write_all(&vaa.payload)?;
         v.into_inner()
     };
 

--- a/solana/bridge/program/src/api/verify_signature.rs
+++ b/solana/bridge/program/src/api/verify_signature.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::collapsible_if)]
 use solitaire::*;
 
 use crate::{
@@ -83,10 +84,10 @@ pub fn verify_signatures(
                 return None;
             }
 
-            return Some(SigInfo {
+            Some(SigInfo {
                 sig_index: *p as u8,
                 signer_index: i as u8,
-            });
+            })
         })
         .collect();
 

--- a/solana/bridge/program/src/instructions.rs
+++ b/solana/bridge/program/src/instructions.rs
@@ -121,7 +121,7 @@ pub fn post_message(
             crate::instruction::Instruction::PostMessage,
             PostMessageData {
                 nonce,
-                payload: payload.clone(),
+                payload,
                 consistency_level: commitment,
             },
         )
@@ -178,7 +178,7 @@ pub fn post_vaa(
     };
 
     let message =
-        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(&msg_derivation_data, &program_id);
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, &program_id);
 
     Instruction {
         program_id,
@@ -389,10 +389,10 @@ pub fn serialize_vaa(vaa: &PostVAAData) -> Vec<u8> {
     v.write_u32::<BigEndian>(vaa.timestamp).unwrap();
     v.write_u32::<BigEndian>(vaa.nonce).unwrap();
     v.write_u16::<BigEndian>(vaa.emitter_chain).unwrap();
-    v.write(&vaa.emitter_address).unwrap();
+    v.write_all(&vaa.emitter_address).unwrap();
     v.write_u64::<BigEndian>(vaa.sequence).unwrap();
     v.write_u8(vaa.consistency_level).unwrap();
-    v.write(&vaa.payload).unwrap();
+    v.write_all(&vaa.payload).unwrap();
     v.into_inner()
 }
 
@@ -400,6 +400,6 @@ pub fn serialize_vaa(vaa: &PostVAAData) -> Vec<u8> {
 pub fn hash_vaa(vaa: &PostVAAData) -> [u8; 32] {
     let body = serialize_vaa(vaa);
     let mut h = sha3::Keccak256::default();
-    h.write(body.as_slice()).unwrap();
+    h.write_all(body.as_slice()).unwrap();
     h.finalize().into()
 }

--- a/solana/bridge/program/src/instructions.rs
+++ b/solana/bridge/program/src/instructions.rs
@@ -268,7 +268,7 @@ pub fn upgrade_guardian_set(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,
-            sequence: sequence,
+            sequence,
         },
         &program_id,
     );

--- a/solana/bridge/program/src/types.rs
+++ b/solana/bridge/program/src/types.rs
@@ -51,7 +51,7 @@ pub struct GovernancePayloadUpgrade {
 
 impl SerializePayload for GovernancePayloadUpgrade {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
-        v.write(&self.new_contract.to_bytes())?;
+        v.write_all(&self.new_contract.to_bytes())?;
         Ok(())
     }
 }
@@ -99,7 +99,7 @@ impl SerializePayload for GovernancePayloadGuardianSetChange {
         v.write_u32::<BigEndian>(self.new_guardian_set_index)?;
         v.write_u8(self.new_guardian_set.len() as u8)?;
         for key in self.new_guardian_set.iter() {
-            v.write(key)?;
+            v.write_all(key)?;
         }
         Ok(())
     }
@@ -119,7 +119,7 @@ where
         let mut keys = Vec::with_capacity(keys_len as usize);
         for _ in 0..keys_len {
             let mut key: [u8; 20] = [0; 20];
-            c.read(&mut key)?;
+            c.read_exact(&mut key)?;
             keys.push(key);
         }
 
@@ -151,7 +151,7 @@ impl SerializePayload for GovernancePayloadSetMessageFee {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
         let mut fee_data = [0u8; 32];
         self.fee.to_big_endian(&mut fee_data);
-        v.write(&fee_data[..])?;
+        v.write_all(&fee_data[..])?;
 
         Ok(())
     }
@@ -197,8 +197,8 @@ impl SerializePayload for GovernancePayloadTransferFees {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
         let mut amount_data = [0u8; 32];
         self.amount.to_big_endian(&mut amount_data);
-        v.write(&amount_data)?;
-        v.write(&self.to)?;
+        v.write_all(&amount_data)?;
+        v.write_all(&self.to)?;
         Ok(())
     }
 }

--- a/solana/bridge/program/src/vaa.rs
+++ b/solana/bridge/program/src/vaa.rs
@@ -8,7 +8,6 @@ use crate::{
         InvalidGovernanceChain,
         InvalidGovernanceModule,
         VAAAlreadyExecuted,
-        VAAInvalid,
     },
     Claim,
     ClaimDerivationData,

--- a/solana/bridge/program/src/vaa.rs
+++ b/solana/bridge/program/src/vaa.rs
@@ -79,7 +79,7 @@ pub trait SerializeGovernancePayload: SerializePayload {
         use byteorder::WriteBytesExt;
         let module = format!("{:\0>32}", Self::MODULE);
         let module = module.as_bytes();
-        c.write(&module)?;
+        c.write_all(module)?;
         c.write_u8(Self::ACTION)?;
         c.write_u16::<BigEndian>(CHAIN_ID_SOLANA)?;
         Ok(())
@@ -247,39 +247,49 @@ impl VAA {
 
     pub fn deserialize(data: &[u8]) -> std::result::Result<VAA, std::io::Error> {
         let mut rdr = Cursor::new(data);
-        let mut v = VAA::default();
 
-        v.version = rdr.read_u8()?;
-        v.guardian_set_index = rdr.read_u32::<BigEndian>()?;
+        let version = rdr.read_u8()?;
+        let guardian_set_index = rdr.read_u32::<BigEndian>()?;
 
         let len_sig = rdr.read_u8()?;
-        let mut sigs: Vec<VAASignature> = Vec::with_capacity(len_sig as usize);
+        let mut signatures: Vec<VAASignature> = Vec::with_capacity(len_sig as usize);
         for _i in 0..len_sig {
-            let mut sig = VAASignature::default();
-
-            sig.guardian_index = rdr.read_u8()?;
+            let guardian_index = rdr.read_u8()?;
             let mut signature_data = [0u8; 65];
             rdr.read_exact(&mut signature_data)?;
-            sig.signature = signature_data.to_vec();
+            let signature = signature_data.to_vec();
 
-            sigs.push(sig);
+            signatures.push(VAASignature {
+                guardian_index,
+                signature,
+            });
         }
-        v.signatures = sigs;
 
-        v.timestamp = rdr.read_u32::<BigEndian>()?;
-        v.nonce = rdr.read_u32::<BigEndian>()?;
-        v.emitter_chain = rdr.read_u16::<BigEndian>()?;
+        let timestamp = rdr.read_u32::<BigEndian>()?;
+        let nonce = rdr.read_u32::<BigEndian>()?;
+        let emitter_chain = rdr.read_u16::<BigEndian>()?;
 
         let mut emitter_address = [0u8; 32];
         rdr.read_exact(&mut emitter_address)?;
-        v.emitter_address = emitter_address;
 
-        v.sequence = rdr.read_u64::<BigEndian>()?;
-        v.consistency_level = rdr.read_u8()?;
+        let sequence = rdr.read_u64::<BigEndian>()?;
+        let consistency_level = rdr.read_u8()?;
 
-        rdr.read_to_end(&mut v.payload)?;
+        let mut payload = Vec::new();
+        rdr.read_to_end(&mut payload)?;
 
-        Ok(v)
+        Ok(VAA {
+            version,
+            guardian_set_index,
+            signatures,
+            timestamp,
+            nonce,
+            emitter_chain,
+            emitter_address,
+            sequence,
+            consistency_level,
+            payload,
+        })
     }
 }
 

--- a/solana/bridge/program_stub/src/api/post_vaa.rs
+++ b/solana/bridge/program_stub/src/api/post_vaa.rs
@@ -12,13 +12,11 @@ use solana_program::{
 use bridge::{
     accounts::{
         Bridge,
-        GuardianSetDerivationData,
         PostedVAA,
         PostedVAADerivationData,
     },
     instructions::hash_vaa,
     PostVAAData,
-    CHAIN_ID_SOLANA,
 };
 use solitaire::{
     processors::seeded::Seeded,
@@ -60,7 +58,7 @@ pub struct Signature {
 pub type ForeignAddress = [u8; 32];
 
 pub fn post_vaa(ctx: &ExecutionContext, accs: &mut PostVAA, vaa: PostVAAData) -> Result<()> {
-    let mut msg_derivation = PostedVAADerivationData {
+    let msg_derivation = PostedVAADerivationData {
         payload_hash: hash_vaa(&vaa).to_vec(),
     };
 

--- a/solana/bridge/program_stub/src/lib.rs
+++ b/solana/bridge/program_stub/src/lib.rs
@@ -20,8 +20,6 @@ pub use api::{
     UninitializedMessage,
 };
 
-use bridge::PostVAAData;
-
 solitaire! {
     Initialize  => initialize,
     PostMessage => post_message,

--- a/solana/modules/nft_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/nft_bridge/program/src/api/complete_transfer.rs
@@ -214,7 +214,6 @@ pub fn complete_wrapped(
     accs: &mut CompleteWrapped,
     _data: CompleteWrappedData,
 ) -> Result<()> {
-    use bstr::ByteSlice;
 
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();

--- a/solana/modules/nft_bridge/program/src/api/governance.rs
+++ b/solana/modules/nft_bridge/program/src/api/governance.rs
@@ -36,7 +36,7 @@ use solitaire::{
 };
 
 // Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
-fn verify_governance<'a, T>(vaa: &ClaimableVAA<'a, T>) -> Result<()>
+fn verify_governance<T>(vaa: &ClaimableVAA<T>) -> Result<()>
 where
     T: DeserializePayload,
 {
@@ -95,7 +95,7 @@ pub fn upgrade_contract(
     _data: UpgradeContractData,
 ) -> Result<()> {
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(&ctx.program_id)?;
+    accs.vaa.verify(ctx.program_id)?;
 
     accs.vaa.claim(ctx, accs.payer.key)?;
 
@@ -152,7 +152,7 @@ pub fn register_chain(
 
     // Claim VAA
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(&ctx.program_id)?;
+    accs.vaa.verify(ctx.program_id)?;
     accs.vaa.claim(ctx, accs.payer.key)?;
 
     if accs.vaa.chain == CHAIN_ID_SOLANA {

--- a/solana/modules/nft_bridge/program/src/instructions.rs
+++ b/solana/modules/nft_bridge/program/src/instructions.rs
@@ -36,24 +36,13 @@ use borsh::BorshSerialize;
 use bridge::{
     accounts::{
         Bridge,
-        BridgeConfig,
         Claim,
         ClaimDerivationData,
         FeeCollector,
-        PostedVAA,
-        PostedVAAData,
-        PostedVAADerivationData,
         Sequence,
         SequenceDerivationData,
     },
     api::ForeignAddress,
-    instructions::hash_vaa,
-    vaa::{
-        ClaimableVAA,
-        PayloadMessage,
-        SerializePayload,
-    },
-    PostVAA,
     PostVAAData,
     CHAIN_ID_SOLANA,
 };
@@ -69,8 +58,6 @@ use solitaire::{
     processors::seeded::Seeded,
     AccountState,
 };
-use spl_token::state::Mint;
-use std::str::FromStr;
 
 pub fn initialize(
     program_id: Pubkey,
@@ -91,6 +78,7 @@ pub fn initialize(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_native(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -143,6 +131,7 @@ pub fn complete_native(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_wrapped(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -215,7 +204,7 @@ pub fn complete_wrapped_meta(
     data: CompleteWrappedMetaData,
 ) -> solitaire::Result<Instruction> {
     let config_key = ConfigAccount::<'_, { AccountState::Uninitialized }>::key(None, &program_id);
-    let (message_acc, claim_acc) = claimable_vaa(program_id, message_key, vaa.clone());
+    let (message_acc, _claim_acc) = claimable_vaa(program_id, message_key, vaa.clone());
     let endpoint = Endpoint::<'_, { AccountState::Initialized }>::key(
         &EndpointDerivationData {
             emitter_chain: vaa.emitter_chain,
@@ -345,7 +334,7 @@ pub fn transfer_native(
 
     // SPL Metadata
     let spl_metadata = SplTokenMeta::key(
-        &SplTokenMetaDerivationData { mint: mint },
+        &SplTokenMetaDerivationData { mint },
         &spl_token_metadata::id(),
     );
 
@@ -387,6 +376,7 @@ pub fn transfer_native(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_wrapped(
     program_id: Pubkey,
     bridge_id: Pubkey,

--- a/solana/modules/nft_bridge/program/src/messages.rs
+++ b/solana/modules/nft_bridge/program/src/messages.rs
@@ -113,33 +113,34 @@ impl DeserializePayload for PayloadTransfer {
 }
 
 impl SerializePayload for PayloadTransfer {
+    #[allow(clippy::manual_memcpy)]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SolitaireError> {
         // Payload ID
         writer.write_u8(1)?;
 
-        writer.write(&self.token_address)?;
+        writer.write_all(&self.token_address)?;
         writer.write_u16::<BigEndian>(self.token_chain)?;
 
         let mut symbol: [u8; 32] = [0; 32];
         for i in 0..self.symbol.len() {
             symbol[i] = self.symbol.as_bytes()[i];
         }
-        writer.write(&symbol)?;
+        writer.write_all(&symbol)?;
 
         let mut name: [u8; 32] = [0; 32];
         for i in 0..self.name.len() {
             name[i] = self.name.as_bytes()[i];
         }
-        writer.write(&name)?;
+        writer.write_all(&name)?;
 
         let mut id_data: [u8; 32] = [0; 32];
         self.token_id.to_big_endian(&mut id_data);
-        writer.write(&id_data)?;
+        writer.write_all(&id_data)?;
 
         writer.write_u8(self.uri.len() as u8)?;
-        writer.write(self.uri.as_bytes())?;
+        writer.write_all(self.uri.as_bytes())?;
 
-        writer.write(&self.to)?;
+        writer.write_all(&self.to)?;
         writer.write_u16::<BigEndian>(self.to_chain)?;
 
         Ok(())
@@ -193,7 +194,7 @@ where
         self.write_governance_header(writer)?;
         // Payload ID
         writer.write_u16::<BigEndian>(self.chain)?;
-        writer.write(&self.endpoint_address[..])?;
+        writer.write_all(&self.endpoint_address[..])?;
 
         Ok(())
     }
@@ -208,7 +209,7 @@ pub struct GovernancePayloadUpgrade {
 impl SerializePayload for GovernancePayloadUpgrade {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
         self.write_governance_header(v)?;
-        v.write(&self.new_contract.to_bytes())?;
+        v.write_all(&self.new_contract.to_bytes())?;
         Ok(())
     }
 }
@@ -243,6 +244,7 @@ impl DeserializeGovernancePayload for GovernancePayloadUpgrade {
 }
 
 #[cfg(feature = "no-entrypoint")]
+#[allow(unused_imports)]
 mod tests {
     use crate::messages::{
         GovernancePayloadUpgrade,
@@ -275,7 +277,7 @@ mod tests {
             token_id: U256::from(1234),
         };
 
-        let mut data = transfer_original.try_to_vec().unwrap();
+        let data = transfer_original.try_to_vec().unwrap();
         let transfer_deser = PayloadTransfer::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(transfer_original, transfer_deser);
@@ -287,7 +289,7 @@ mod tests {
             new_contract: Pubkey::new_unique(),
         };
 
-        let mut data = original.try_to_vec().unwrap();
+        let data = original.try_to_vec().unwrap();
         let deser = GovernancePayloadUpgrade::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(original, deser);
@@ -303,7 +305,7 @@ mod tests {
             endpoint_address,
         };
 
-        let mut data = original.try_to_vec().unwrap();
+        let data = original.try_to_vec().unwrap();
         let deser = PayloadGovernanceRegisterChain::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(original, deser);

--- a/solana/modules/nft_bridge/program/src/messages.rs
+++ b/solana/modules/nft_bridge/program/src/messages.rs
@@ -21,10 +21,13 @@ use solana_program::{
     pubkey::Pubkey,
 };
 use solitaire::SolitaireError;
-use std::io::{
-    Cursor,
-    Read,
-    Write,
+use std::{
+    cmp,
+    io::{
+        Cursor,
+        Read,
+        Write,
+    },
 };
 
 pub const MODULE: &str = "NFTBridge";
@@ -113,7 +116,6 @@ impl DeserializePayload for PayloadTransfer {
 }
 
 impl SerializePayload for PayloadTransfer {
-    #[allow(clippy::manual_memcpy)]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SolitaireError> {
         // Payload ID
         writer.write_u8(1)?;
@@ -122,15 +124,14 @@ impl SerializePayload for PayloadTransfer {
         writer.write_u16::<BigEndian>(self.token_chain)?;
 
         let mut symbol: [u8; 32] = [0; 32];
-        for i in 0..self.symbol.len() {
-            symbol[i] = self.symbol.as_bytes()[i];
-        }
+        let count = cmp::min(symbol.len(), self.symbol.len());
+        symbol[..count].copy_from_slice(self.symbol[..count].as_bytes());
+
         writer.write_all(&symbol)?;
 
         let mut name: [u8; 32] = [0; 32];
-        for i in 0..self.name.len() {
-            name[i] = self.name.as_bytes()[i];
-        }
+        let count = cmp::min(name.len(), self.name.len());
+        name[..count].copy_from_slice(self.name[..count].as_bytes());
         writer.write_all(&name)?;
 
         let mut id_data: [u8; 32] = [0; 32];

--- a/solana/modules/nft_bridge/program/tests/integration.rs
+++ b/solana/modules/nft_bridge/program/tests/integration.rs
@@ -1,51 +1,15 @@
-#![allow(warnings)]
-
-use borsh::BorshSerialize;
 use bridge::{
     accounts::{
-        Bridge,
-        FeeCollector,
-        GuardianSet,
-        GuardianSetDerivationData,
         PostedVAA,
         PostedVAADerivationData,
-        SignatureSet,
     },
-    instruction,
-    types::{
-        GovernancePayloadGuardianSetChange,
-        GovernancePayloadSetMessageFee,
-        GovernancePayloadTransferFees,
-    },
-    BridgeConfig,
-    BridgeData,
-    GuardianSetData,
-    Initialize,
-    MessageData,
-    PostVAA,
-    PostVAAData,
-    PostedVAAData,
-    SequenceTracker,
     SerializePayload,
-    Signature,
-    SignatureSet as SignatureSetData,
 };
-use byteorder::{
-    BigEndian,
-    WriteBytesExt,
-};
-use hex_literal::hex;
-use libsecp256k1::{
-    Message as Secp256k1Message,
-    PublicKey,
-    SecretKey,
-};
+
+use libsecp256k1::SecretKey;
 use nft_bridge::{
     accounts::{
         ConfigAccount,
-        EmitterAccount,
-        SplTokenMeta,
-        SplTokenMetaDerivationData,
         WrappedDerivationData,
         WrappedMint,
     },
@@ -53,63 +17,27 @@ use nft_bridge::{
         PayloadGovernanceRegisterChain,
         PayloadTransfer,
     },
-    types::{
-        Address,
-        Config,
-    },
+    types::Config,
 };
 use primitive_types::U256;
 use rand::Rng;
-use sha3::Digest;
-use solana_program::{
-    borsh::try_from_slice_unchecked,
-    hash,
-    instruction::{
-        AccountMeta,
-        Instruction,
-    },
-    program_pack::Pack,
-    pubkey::Pubkey,
-    system_instruction::{
-        self,
-        create_account,
-    },
-    system_program,
-    sysvar,
-};
+use solana_program::pubkey::Pubkey;
 use solana_program_test::{
     tokio,
     BanksClient,
 };
 use solana_sdk::{
-    commitment_config::CommitmentLevel,
     signature::{
-        read_keypair_file,
         Keypair,
         Signer,
     },
-    transaction::Transaction,
     transport::TransportError,
 };
 use solitaire::{
     processors::seeded::Seeded,
     AccountState,
 };
-use spl_token::state::Mint;
-use std::{
-    collections::HashMap,
-    convert::TryInto,
-    io::{
-        Cursor,
-        Write,
-    },
-    str::FromStr,
-    time::{
-        Duration,
-        SystemTime,
-        UNIX_EPOCH,
-    },
-};
+use std::str::FromStr;
 
 mod common;
 
@@ -121,9 +49,6 @@ const GOVERNANCE_KEY: [u8; 64] = [
 ];
 
 struct Context {
-    /// Guardian public keys.
-    guardians: Vec<[u8; 20]>,
-
     /// Guardian secret keys.
     guardian_keys: Vec<SecretKey>,
 
@@ -142,7 +67,6 @@ struct Context {
     /// Keypairs for mint information, required in multiple tests.
     mint_authority: Keypair,
     mint: Keypair,
-    mint_meta: Pubkey,
 
     /// Keypairs for test token accounts.
     token_authority: Keypair,
@@ -170,22 +94,13 @@ async fn set_up() -> Result<Context, TransportError> {
         mint_pubkey.as_ref(),
     ];
 
-    let (metadata_key, metadata_bump_seed) = Pubkey::find_program_address(
+    let (metadata_key, _metadata_bump_seed) = Pubkey::find_program_address(
         metadata_seeds,
         &Pubkey::from_str("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s").unwrap(),
     );
 
     // Token Bridge Meta
-    use nft_bridge::accounts::WrappedTokenMeta;
-    let metadata_account = WrappedTokenMeta::<'_, { AccountState::Uninitialized }>::key(
-        &nft_bridge::accounts::WrappedMetaDerivationData {
-            mint_key: mint_pubkey.clone(),
-        },
-        &nft_bridge,
-    );
-
     let mut context = Context {
-        guardians,
         guardian_keys,
         bridge,
         client,
@@ -193,7 +108,6 @@ async fn set_up() -> Result<Context, TransportError> {
         nft_bridge,
         mint_authority: Keypair::new(),
         mint,
-        mint_meta: metadata_account,
         token_account: Keypair::new(),
         token_authority: Keypair::new(),
         metadata_account: metadata_key,
@@ -270,9 +184,8 @@ async fn transfer_native() {
         ref mut client,
         bridge,
         nft_bridge,
-        ref mint_authority,
+        mint_authority: _,
         ref mint,
-        ref mint_meta,
         ref token_account,
         ref token_authority,
         ..
@@ -300,10 +213,9 @@ async fn register_chain(context: &mut Context) {
         ref mut client,
         ref bridge,
         ref nft_bridge,
-        ref mint_authority,
-        ref mint,
-        ref mint_meta,
-        ref token_authority,
+        mint_authority: _,
+        mint: _,
+        token_authority: _,
         ref guardian_keys,
         ..
     } = context;
@@ -317,18 +229,18 @@ async fn register_chain(context: &mut Context) {
     let message = payload.try_to_vec().unwrap();
 
     let (vaa, body, _) = common::generate_vaa(emitter.pubkey().to_bytes(), 1, message, nonce, 0);
-    let signature_set = common::verify_signatures(client, &bridge, payer, body, guardian_keys, 0)
+    let signature_set = common::verify_signatures(client, bridge, payer, body, guardian_keys, 0)
         .await
         .unwrap();
     common::post_vaa(client, *bridge, payer, signature_set, vaa.clone())
         .await
         .unwrap();
 
-    let mut msg_derivation_data = &PostedVAADerivationData {
+    let msg_derivation_data = &PostedVAADerivationData {
         payload_hash: body.to_vec(),
     };
     let message_key =
-        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(&msg_derivation_data, bridge);
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, bridge);
 
     common::register_chain(
         client,
@@ -352,9 +264,8 @@ async fn transfer_native_in() {
         ref mut client,
         bridge,
         nft_bridge,
-        ref mint_authority,
+        mint_authority: _,
         ref mint,
-        ref mint_meta,
         ref token_account,
         ref token_authority,
         ref guardian_keys,
@@ -388,8 +299,8 @@ async fn transfer_native_in() {
     );
 
     let payload = PayloadTransfer {
-        token_address: [1u8; 32],
-        token_chain: 1,
+        token_address,
+        token_chain,
         symbol: "NFT".into(),
         name: "Non-Fungible Token".into(),
         token_id,
@@ -410,7 +321,7 @@ async fn transfer_native_in() {
         payload_hash: body.to_vec(),
     };
     let message_key =
-        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(&msg_derivation_data, &bridge);
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, &bridge);
 
     common::complete_native(
         client,
@@ -437,13 +348,12 @@ async fn transfer_wrapped() {
         ref mut client,
         bridge,
         nft_bridge,
-        ref mint_authority,
-        ref mint,
-        ref mint_meta,
-        ref token_account,
+        mint_authority: _,
+        mint: _,
+        token_account: _,
         ref token_authority,
         ref guardian_keys,
-        metadata_account,
+        metadata_account: _,
         ..
     } = context;
 
@@ -489,11 +399,11 @@ async fn transfer_wrapped() {
     common::post_vaa(client, bridge, payer, signature_set, vaa.clone())
         .await
         .unwrap();
-    let mut msg_derivation_data = &PostedVAADerivationData {
+    let msg_derivation_data = &PostedVAADerivationData {
         payload_hash: body.to_vec(),
     };
     let message_key =
-        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(&msg_derivation_data, &bridge);
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, &bridge);
 
     common::complete_wrapped(
         client,

--- a/solana/modules/nft_bridge/program/tests/integration.rs
+++ b/solana/modules/nft_bridge/program/tests/integration.rs
@@ -184,7 +184,6 @@ async fn transfer_native() {
         ref mut client,
         bridge,
         nft_bridge,
-        mint_authority: _,
         ref mint,
         ref token_account,
         ref token_authority,
@@ -213,9 +212,6 @@ async fn register_chain(context: &mut Context) {
         ref mut client,
         ref bridge,
         ref nft_bridge,
-        mint_authority: _,
-        mint: _,
-        token_authority: _,
         ref guardian_keys,
         ..
     } = context;

--- a/solana/modules/token_bridge/program/src/accounts.rs
+++ b/solana/modules/token_bridge/program/src/accounts.rs
@@ -2,10 +2,6 @@ use crate::types::*;
 use bridge::{
     accounts::BridgeData,
     api::ForeignAddress,
-    vaa::{
-        DeserializePayload,
-        PayloadMessage,
-    },
 };
 use solana_program::pubkey::Pubkey;
 use solitaire::{
@@ -17,35 +13,35 @@ pub type AuthoritySigner<'b> = Derive<Info<'b>, "authority_signer">;
 pub type CustodySigner<'b> = Derive<Info<'b>, "custody_signer">;
 pub type MintSigner<'b> = Derive<Info<'b>, "mint_signer">;
 
-pub type CoreBridge<'a, const State: AccountState> = Data<'a, BridgeData, { State }>;
+pub type CoreBridge<'a, const STATE: AccountState> = Data<'a, BridgeData, { STATE }>;
 
 pub type EmitterAccount<'b> = Derive<Info<'b>, "emitter">;
 
-pub type ConfigAccount<'b, const State: AccountState> =
-    Derive<Data<'b, Config, { State }>, "config">;
+pub type ConfigAccount<'b, const STATE: AccountState> =
+    Derive<Data<'b, Config, { STATE }>, "config">;
 
-pub type CustodyAccount<'b, const State: AccountState> = Data<'b, SplAccount, { State }>;
+pub type CustodyAccount<'b, const STATE: AccountState> = Data<'b, SplAccount, { STATE }>;
 
 pub struct CustodyAccountDerivationData {
     pub mint: Pubkey,
 }
 
-impl<'b, const State: AccountState> Seeded<&CustodyAccountDerivationData>
-    for CustodyAccount<'b, { State }>
+impl<'b, const STATE: AccountState> Seeded<&CustodyAccountDerivationData>
+    for CustodyAccount<'b, { STATE }>
 {
     fn seeds(accs: &CustodyAccountDerivationData) -> Vec<Vec<u8>> {
         vec![accs.mint.to_bytes().to_vec()]
     }
 }
 
-pub type WrappedMint<'b, const State: AccountState> = Data<'b, SplMint, { State }>;
+pub type WrappedMint<'b, const STATE: AccountState> = Data<'b, SplMint, { STATE }>;
 
 pub struct WrappedDerivationData {
     pub token_chain: ChainID,
     pub token_address: ForeignAddress,
 }
 
-impl<'b, const State: AccountState> Seeded<&WrappedDerivationData> for WrappedMint<'b, { State }> {
+impl<'b, const STATE: AccountState> Seeded<&WrappedDerivationData> for WrappedMint<'b, { STATE }> {
     fn seeds(data: &WrappedDerivationData) -> Vec<Vec<u8>> {
         vec![
             String::from("wrapped").as_bytes().to_vec(),
@@ -55,14 +51,14 @@ impl<'b, const State: AccountState> Seeded<&WrappedDerivationData> for WrappedMi
     }
 }
 
-pub type WrappedTokenMeta<'b, const State: AccountState> = Data<'b, WrappedMeta, { State }>;
+pub type WrappedTokenMeta<'b, const STATE: AccountState> = Data<'b, WrappedMeta, { STATE }>;
 
 pub struct WrappedMetaDerivationData {
     pub mint_key: Pubkey,
 }
 
-impl<'b, const State: AccountState> Seeded<&WrappedMetaDerivationData>
-    for WrappedTokenMeta<'b, { State }>
+impl<'b, const STATE: AccountState> Seeded<&WrappedMetaDerivationData>
+    for WrappedTokenMeta<'b, { STATE }>
 {
     fn seeds(data: &WrappedMetaDerivationData) -> Vec<Vec<u8>> {
         vec![
@@ -73,7 +69,7 @@ impl<'b, const State: AccountState> Seeded<&WrappedMetaDerivationData>
 }
 
 /// Registered chain endpoint
-pub type Endpoint<'b, const State: AccountState> = Data<'b, EndpointRegistration, { State }>;
+pub type Endpoint<'b, const STATE: AccountState> = Data<'b, EndpointRegistration, { STATE }>;
 
 pub struct EndpointDerivationData {
     pub emitter_chain: u16,
@@ -81,7 +77,7 @@ pub struct EndpointDerivationData {
 }
 
 /// Seeded implementation based on an incoming VAA
-impl<'b, const State: AccountState> Seeded<&EndpointDerivationData> for Endpoint<'b, { State }> {
+impl<'b, const STATE: AccountState> Seeded<&EndpointDerivationData> for Endpoint<'b, { STATE }> {
     fn seeds(data: &EndpointDerivationData) -> Vec<Vec<u8>> {
         vec![
             data.emitter_chain.to_be_bytes().to_vec(),

--- a/solana/modules/token_bridge/program/src/api/attest.rs
+++ b/solana/modules/token_bridge/program/src/api/attest.rs
@@ -8,62 +8,33 @@ use crate::{
         WrappedMetaDerivationData,
         WrappedTokenMeta,
     },
-    messages::{
-        PayloadAssetMeta,
-        PayloadTransfer,
-    },
+    messages::PayloadAssetMeta,
     types::*,
-    TokenBridgeError::{
-        self,
-        *,
-    },
+    TokenBridgeError::*,
 };
 use bridge::{
-    accounts::Bridge,
-    api::{
-        PostMessage,
-        PostMessageData,
-    },
+    api::PostMessageData,
     types::ConsistencyLevel,
     vaa::SerializePayload,
     CHAIN_ID_SOLANA,
 };
-use primitive_types::U256;
 use solana_program::{
     account_info::AccountInfo,
     instruction::{
         AccountMeta,
         Instruction,
     },
-    program::{
-        invoke,
-        invoke_signed,
-    },
-    program_error::ProgramError,
-    pubkey::Pubkey,
+    program::invoke,
     sysvar::clock::Clock,
 };
 use solitaire::{
     processors::seeded::{
         invoke_seeded,
-        Owned,
         Seeded,
     },
-    CreationLamports::Exempt,
     *,
 };
-use spl_token::{
-    error::TokenError::OwnerMismatch,
-    state::{
-        Account,
-        Mint,
-    },
-};
 use spl_token_metadata::state::Metadata;
-use std::ops::{
-    Deref,
-    DerefMut,
-};
 
 #[derive(FromAccounts)]
 pub struct AttestToken<'b> {

--- a/solana/modules/token_bridge/program/src/api/attest.rs
+++ b/solana/modules/token_bridge/program/src/api/attest.rs
@@ -132,7 +132,7 @@ pub fn attest_token(
         let metadata: Metadata =
             Metadata::from_account_info(accs.spl_metadata.info()).ok_or(InvalidMetadata)?;
         payload.name = metadata.data.name.clone();
-        payload.symbol = metadata.data.symbol.clone();
+        payload.symbol = metadata.data.symbol;
     }
 
     let params = (

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -21,27 +21,13 @@ use bridge::{
     vaa::ClaimableVAA,
     CHAIN_ID_SOLANA,
 };
-use solana_program::{
-    account_info::AccountInfo,
-    program::invoke_signed,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-};
+use solana_program::account_info::AccountInfo;
 use solitaire::{
     processors::seeded::{
         invoke_seeded,
         Seeded,
     },
-    CreationLamports::Exempt,
     *,
-};
-use spl_token::state::{
-    Account,
-    Mint,
-};
-use std::ops::{
-    Deref,
-    DerefMut,
 };
 
 #[derive(FromAccounts)]
@@ -86,7 +72,7 @@ pub struct CompleteNativeData {}
 pub fn complete_native(
     ctx: &ExecutionContext,
     accs: &mut CompleteNative,
-    data: CompleteNativeData,
+    _data: CompleteNativeData,
 ) -> Result<()> {
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
@@ -212,7 +198,7 @@ pub struct CompleteWrappedData {}
 pub fn complete_wrapped(
     ctx: &ExecutionContext,
     accs: &mut CompleteWrapped,
-    data: CompleteWrappedData,
+    _data: CompleteWrappedData,
 ) -> Result<()> {
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();

--- a/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
@@ -12,10 +12,7 @@ use crate::{
         WrappedMint,
         WrappedTokenMeta,
     },
-    messages::{
-        PayloadTransfer,
-        PayloadTransferWithPayload,
-    },
+    messages::PayloadTransferWithPayload,
     types::*,
     TokenBridgeError::*,
 };
@@ -23,27 +20,13 @@ use bridge::{
     vaa::ClaimableVAA,
     CHAIN_ID_SOLANA,
 };
-use solana_program::{
-    account_info::AccountInfo,
-    program::invoke_signed,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-};
+use solana_program::account_info::AccountInfo;
 use solitaire::{
     processors::seeded::{
         invoke_seeded,
         Seeded,
     },
-    CreationLamports::Exempt,
     *,
-};
-use spl_token::state::{
-    Account,
-    Mint,
-};
-use std::ops::{
-    Deref,
-    DerefMut,
 };
 
 #[derive(FromAccounts)]
@@ -99,7 +82,7 @@ pub struct CompleteNativeWithPayloadData {}
 pub fn complete_native_with_payload(
     ctx: &ExecutionContext,
     accs: &mut CompleteNativeWithPayload,
-    data: CompleteNativeWithPayloadData,
+    _data: CompleteNativeWithPayloadData,
 ) -> Result<()> {
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
@@ -187,7 +170,7 @@ pub struct CompleteWrappedWithPayload<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
-    // Signed message for the transfer
+    /// Signed message for the transfer
     pub vaa: ClaimableVAA<'b, PayloadTransferWithPayload>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
@@ -238,7 +221,7 @@ pub struct CompleteWrappedWithPayloadData {}
 pub fn complete_wrapped_with_payload(
     ctx: &ExecutionContext,
     accs: &mut CompleteWrappedWithPayload,
-    data: CompleteWrappedWithPayloadData,
+    _data: CompleteWrappedWithPayloadData,
 ) -> Result<()> {
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();

--- a/solana/modules/token_bridge/program/src/api/create_wrapped.rs
+++ b/solana/modules/token_bridge/program/src/api/create_wrapped.rs
@@ -12,7 +12,6 @@ use crate::{
         WrappedTokenMeta,
     },
     messages::PayloadAssetMeta,
-    types::*,
     TokenBridgeError::{
         InvalidChain,
         InvalidMetadata,
@@ -27,8 +26,6 @@ use bridge::{
 use solana_program::{
     account_info::AccountInfo,
     program::invoke_signed,
-    program_error::ProgramError,
-    pubkey::Pubkey,
 };
 use solitaire::{
     processors::seeded::{
@@ -38,24 +35,12 @@ use solitaire::{
     CreationLamports::Exempt,
     *,
 };
-use spl_token::{
-    error::TokenError::OwnerMismatch,
-    state::{
-        Account,
-        Mint,
-    },
-};
+
 use spl_token_metadata::state::{
     Data as SplData,
     Metadata,
 };
-use std::{
-    cmp::min,
-    ops::{
-        Deref,
-        DerefMut,
-    },
-};
+use std::cmp::min;
 
 #[derive(FromAccounts)]
 pub struct CreateWrapped<'b> {
@@ -146,7 +131,7 @@ pub fn create_wrapped(
 pub fn create_accounts(
     ctx: &ExecutionContext,
     accs: &mut CreateWrapped,
-    data: CreateWrappedData,
+    _data: CreateWrappedData,
 ) -> Result<()> {
     // Create mint account
     accs.mint
@@ -206,7 +191,7 @@ pub fn create_accounts(
 pub fn update_accounts(
     ctx: &ExecutionContext,
     accs: &mut CreateWrapped,
-    data: CreateWrappedData,
+    _data: CreateWrappedData,
 ) -> Result<()> {
     accs.spl_metadata.verify_derivation(
         &spl_token_metadata::id(),
@@ -250,14 +235,6 @@ pub fn truncate_utf8(data: impl AsRef<[u8]>, len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    fn extend_string(n: &str) -> Vec<u8> {
-        let mut bytes = vec![0u8; 32];
-        for i in 0..n.len() {
-            bytes[i] = n.as_bytes()[i];
-        }
-        bytes.to_vec()
-    }
-
     #[test]
     fn test_unicode_truncation() {
         #[rustfmt::skip]

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -8,9 +8,7 @@ use crate::{
         GovernancePayloadUpgrade,
         PayloadGovernanceRegisterChain,
     },
-    types::*,
     TokenBridgeError::{
-        InvalidChain,
         InvalidGovernanceKey,
         InvalidVAA,
     },
@@ -20,14 +18,12 @@ use bridge::{
     vaa::{
         ClaimableVAA,
         DeserializePayload,
-        PayloadMessage,
     },
     CHAIN_ID_SOLANA,
 };
 use solana_program::{
     account_info::AccountInfo,
     program::invoke_signed,
-    program_error::ProgramError,
     pubkey::Pubkey,
     sysvar::{
         clock::Clock,
@@ -39,12 +35,8 @@ use solitaire::{
     CreationLamports::Exempt,
     *,
 };
-use std::ops::{
-    Deref,
-    DerefMut,
-};
 
-// Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
+/// Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
 fn verify_governance<'a, T>(vaa: &ClaimableVAA<'a, T>) -> Result<()>
 where
     T: DeserializePayload,

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -37,7 +37,7 @@ use solitaire::{
 };
 
 /// Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
-fn verify_governance<'a, T>(vaa: &ClaimableVAA<'a, T>) -> Result<()>
+fn verify_governance<T>(vaa: &ClaimableVAA<T>) -> Result<()>
 where
     T: DeserializePayload,
 {

--- a/solana/modules/token_bridge/program/src/api/initialize.rs
+++ b/solana/modules/token_bridge/program/src/api/initialize.rs
@@ -1,20 +1,11 @@
-use crate::{
-    accounts::ConfigAccount,
-    types::*,
-};
+use crate::accounts::ConfigAccount;
 use solana_program::{
     account_info::AccountInfo,
-    msg,
-    program_error::ProgramError,
     pubkey::Pubkey,
 };
 use solitaire::{
     CreationLamports::Exempt,
     *,
-};
-use std::ops::{
-    Deref,
-    DerefMut,
 };
 
 #[derive(FromAccounts)]

--- a/solana/modules/token_bridge/program/src/api/transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/transfer.rs
@@ -26,11 +26,7 @@ use crate::{
     },
 };
 use bridge::{
-    accounts::Bridge,
-    api::{
-        PostMessage,
-        PostMessageData,
-    },
+    api::PostMessageData,
     types::ConsistencyLevel,
     vaa::SerializePayload,
     CHAIN_ID_SOLANA,
@@ -46,9 +42,7 @@ use solana_program::{
         invoke,
         invoke_signed,
     },
-    program_error::ProgramError,
     program_option::COption,
-    pubkey::Pubkey,
     sysvar::clock::Clock,
 };
 use solitaire::{
@@ -58,17 +52,6 @@ use solitaire::{
     },
     CreationLamports::Exempt,
     *,
-};
-use spl_token::{
-    error::TokenError::OwnerMismatch,
-    state::{
-        Account,
-        Mint,
-    },
-};
-use std::ops::{
-    Deref,
-    DerefMut,
 };
 
 pub type TransferNativeWithPayload<'b> = TransferNative<'b>;

--- a/solana/modules/token_bridge/program/src/instructions.rs
+++ b/solana/modules/token_bridge/program/src/instructions.rs
@@ -84,6 +84,7 @@ pub fn initialize(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_native(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -138,6 +139,7 @@ pub fn complete_native(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_native_with_payload(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -198,6 +200,7 @@ pub fn complete_native_with_payload(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_wrapped(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -259,6 +262,7 @@ pub fn complete_wrapped(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn complete_wrapped_with_payload(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -543,6 +547,7 @@ fn transfer_native_raw(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_wrapped(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -567,6 +572,7 @@ pub fn transfer_wrapped(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_wrapped_with_payload(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -595,6 +601,7 @@ pub fn transfer_wrapped_with_payload(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn transfer_wrapped_raw(
     program_id: Pubkey,
     bridge_id: Pubkey,

--- a/solana/modules/token_bridge/program/src/instructions.rs
+++ b/solana/modules/token_bridge/program/src/instructions.rs
@@ -43,28 +43,16 @@ use borsh::BorshSerialize;
 use bridge::{
     accounts::{
         Bridge,
-        BridgeConfig,
         Claim,
         ClaimDerivationData,
         FeeCollector,
-        PostedVAA,
-        PostedVAAData,
-        PostedVAADerivationData,
         Sequence,
         SequenceDerivationData,
     },
     api::ForeignAddress,
-    instructions::hash_vaa,
-    vaa::{
-        ClaimableVAA,
-        PayloadMessage,
-        SerializePayload,
-    },
-    PostVAA,
     PostVAAData,
     CHAIN_ID_SOLANA,
 };
-use primitive_types::U256;
 use solana_program::{
     instruction::{
         AccountMeta,
@@ -75,11 +63,6 @@ use solana_program::{
 use solitaire::{
     processors::seeded::Seeded,
     AccountState,
-};
-use spl_token::state::Mint;
-use std::{
-    cmp::min,
-    str::FromStr,
 };
 
 pub fn initialize(

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -65,7 +65,7 @@ pub use api::{
 use solitaire::*;
 
 // Static list of invalid VAA Message accounts.
-pub(crate) static INVALID_VAAS: &'static [&'static str; 7] = &[
+pub(crate) static INVALID_VAAS: &[&str; 7] = &[
     "28Tx7c3W8rggVNyUQEAL9Uq6pUng4xJLAeLA6V8nLH1Z",
     "32YEuzLCvSyHoV6NFpaTXfiAB8sHiAnYcvP2BBeLeGWq",
     "427N2RrDHYooLvyWCiEiNR4KtGsGFTMuXiGwtuChWRSd",

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(adt_const_params)]
+#![allow(incomplete_features)]
 #![deny(unused_must_use)]
 
 // #![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
@@ -62,7 +63,6 @@ pub use api::{
 };
 
 use solitaire::*;
-use std::error::Error;
 
 // Static list of invalid VAA Message accounts.
 pub(crate) static INVALID_VAAS: &'static [&'static str; 7] = &[

--- a/solana/modules/token_bridge/program/src/messages.rs
+++ b/solana/modules/token_bridge/program/src/messages.rs
@@ -3,11 +3,6 @@ use crate::{
         Address,
         ChainID,
     },
-    TokenBridgeError,
-};
-use borsh::{
-    BorshDeserialize,
-    BorshSerialize,
 };
 use bridge::{
     vaa::{
@@ -24,38 +19,29 @@ use byteorder::{
 };
 use primitive_types::U256;
 use solana_program::{
-    native_token::Sol,
-    program_error::{
-        ProgramError,
-        ProgramError::InvalidAccountData,
-    },
+    program_error::ProgramError::InvalidAccountData,
     pubkey::Pubkey,
 };
 use solitaire::SolitaireError;
-use std::{
-    error::Error,
-    io::{
+use std::io::{
         Cursor,
         Read,
         Write,
-    },
-    str::Utf8Error,
-    string::FromUtf8Error,
-};
+    };
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct PayloadTransfer {
-    // Amount being transferred (big-endian uint256)
+    /// Amount being transferred (big-endian uint256)
     pub amount: U256,
-    // Address of the token. Left-zero-padded if shorter than 32 bytes
+    /// Address of the token. Left-zero-padded if shorter than 32 bytes
     pub token_address: Address,
-    // Chain ID of the token
+    /// Chain ID of the token
     pub token_chain: ChainID,
-    // Address of the recipient. Left-zero-padded if shorter than 32 bytes
+    /// Address of the recipient. Left-zero-padded if shorter than 32 bytes
     pub to: Address,
-    // Chain ID of the recipient
+    /// Chain ID of the recipient
     pub to_chain: ChainID,
-    // Amount of tokens (big-endian uint256) that the user is willing to pay as relayer fee. Must be <= Amount.
+    /// Amount of tokens (big-endian uint256) that the user is willing to pay as relayer fee. Must be <= Amount.
     pub fee: U256,
 }
 
@@ -189,33 +175,33 @@ impl SerializePayload for PayloadTransferWithPayload {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct PayloadTransferWithPayload {
-    // Amount being transferred (big-endian uint256)
+    /// Amount being transferred (big-endian uint256)
     pub amount: U256,
-    // Address of the token. Left-zero-padded if shorter than 32 bytes
+    /// Address of the token. Left-zero-padded if shorter than 32 bytes
     pub token_address: Address,
-    // Chain ID of the token
+    /// Chain ID of the token
     pub token_chain: ChainID,
-    // Address of the recipient. Left-zero-padded if shorter than 32 bytes
+    /// Address of the recipient. Left-zero-padded if shorter than 32 bytes
     pub to: Address,
-    // Chain ID of the recipient
+    /// Chain ID of the recipient
     pub to_chain: ChainID,
-    // Amount of tokens (big-endian uint256) that the user is willing to pay as relayer fee. Must be <= Amount.
+    /// Amount of tokens (big-endian uint256) that the user is willing to pay as relayer fee. Must be <= Amount.
     pub fee: U256,
-    // Arbitrary payload
+    /// Arbitrary payload
     pub payload: Vec<u8>,
 }
 
 #[derive(PartialEq, Debug)]
 pub struct PayloadAssetMeta {
-    // Address of the token. Left-zero-padded if shorter than 32 bytes
+    /// Address of the token. Left-zero-padded if shorter than 32 bytes
     pub token_address: Address,
-    // Chain ID of the token
+    /// Chain ID of the token
     pub token_chain: ChainID,
-    // Number of decimals of the token
+    /// Number of decimals of the token
     pub decimals: u8,
-    // Symbol of the token
+    /// Symbol of the token
     pub symbol: String,
-    // Name of the token
+    /// Name of the token
     pub name: String,
 }
 
@@ -291,9 +277,9 @@ impl SerializePayload for PayloadAssetMeta {
 
 #[derive(PartialEq, Debug)]
 pub struct PayloadGovernanceRegisterChain {
-    // Chain ID of the chain to be registered
+    /// Chain ID of the chain to be registered
     pub chain: ChainID,
-    // Address of the endpoint on the chain
+    /// Address of the endpoint on the chain
     pub endpoint_address: Address,
 }
 
@@ -344,7 +330,7 @@ where
 
 #[derive(PartialEq, Debug)]
 pub struct GovernancePayloadUpgrade {
-    // Address of the new Implementation
+    /// Address of the new Implementation
     pub new_contract: Pubkey,
 }
 
@@ -386,6 +372,7 @@ impl DeserializeGovernancePayload for GovernancePayloadUpgrade {
 }
 
 #[cfg(feature = "no-entrypoint")]
+#[allow(unused_imports)]
 mod tests {
     use crate::messages::{
         GovernancePayloadUpgrade,
@@ -417,7 +404,7 @@ mod tests {
             fee: U256::from(1139),
         };
 
-        let mut data = transfer_original.try_to_vec().unwrap();
+        let data = transfer_original.try_to_vec().unwrap();
         let transfer_deser = PayloadTransfer::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(transfer_original, transfer_deser);
@@ -436,7 +423,7 @@ mod tests {
             name: "ZAC".to_string(),
         };
 
-        let mut data = am_original.try_to_vec().unwrap();
+        let data = am_original.try_to_vec().unwrap();
         let am_deser = PayloadAssetMeta::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(am_original, am_deser);
@@ -448,7 +435,7 @@ mod tests {
             new_contract: Pubkey::new_unique(),
         };
 
-        let mut data = original.try_to_vec().unwrap();
+        let data = original.try_to_vec().unwrap();
         let deser = GovernancePayloadUpgrade::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(original, deser);
@@ -464,7 +451,7 @@ mod tests {
             endpoint_address,
         };
 
-        let mut data = original.try_to_vec().unwrap();
+        let data = original.try_to_vec().unwrap();
         let deser = PayloadGovernanceRegisterChain::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(original, deser);

--- a/solana/modules/token_bridge/program/src/messages.rs
+++ b/solana/modules/token_bridge/program/src/messages.rs
@@ -93,16 +93,16 @@ impl SerializePayload for PayloadTransfer {
 
         let mut am_data: [u8; 32] = [0; 32];
         self.amount.to_big_endian(&mut am_data);
-        writer.write(&am_data)?;
+        writer.write_all(&am_data)?;
 
-        writer.write(&self.token_address)?;
+        writer.write_all(&self.token_address)?;
         writer.write_u16::<BigEndian>(self.token_chain)?;
-        writer.write(&self.to)?;
+        writer.write_all(&self.to)?;
         writer.write_u16::<BigEndian>(self.to_chain)?;
 
         let mut fee_data: [u8; 32] = [0; 32];
         self.fee.to_big_endian(&mut fee_data);
-        writer.write(&fee_data)?;
+        writer.write_all(&fee_data)?;
 
         Ok(())
     }
@@ -156,18 +156,18 @@ impl SerializePayload for PayloadTransferWithPayload {
 
         let mut am_data: [u8; 32] = [0; 32];
         self.amount.to_big_endian(&mut am_data);
-        writer.write(&am_data)?;
+        writer.write_all(&am_data)?;
 
-        writer.write(&self.token_address)?;
+        writer.write_all(&self.token_address)?;
         writer.write_u16::<BigEndian>(self.token_chain)?;
-        writer.write(&self.to)?;
+        writer.write_all(&self.to)?;
         writer.write_u16::<BigEndian>(self.to_chain)?;
 
         let mut fee_data: [u8; 32] = [0; 32];
         self.fee.to_big_endian(&mut fee_data);
-        writer.write(&fee_data)?;
+        writer.write_all(&fee_data)?;
 
-        writer.write(self.payload.as_slice())?;
+        writer.write_all(self.payload.as_slice())?;
 
         Ok(())
     }
@@ -250,11 +250,12 @@ impl DeserializePayload for PayloadAssetMeta {
 }
 
 impl SerializePayload for PayloadAssetMeta {
+    #[allow(clippy::manual_memcpy)]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SolitaireError> {
         // Payload ID
         writer.write_u8(2)?;
 
-        writer.write(&self.token_address)?;
+        writer.write_all(&self.token_address)?;
         writer.write_u16::<BigEndian>(self.token_chain)?;
 
         writer.write_u8(self.decimals)?;
@@ -263,13 +264,13 @@ impl SerializePayload for PayloadAssetMeta {
         for i in 0..self.symbol.len() {
             symbol[i] = self.symbol.as_bytes()[i];
         }
-        writer.write(&symbol)?;
+        writer.write_all(&symbol)?;
 
         let mut name: [u8; 32] = [0; 32];
         for i in 0..self.name.len() {
             name[i] = self.name.as_bytes()[i];
         }
-        writer.write(&name)?;
+        writer.write_all(&name)?;
 
         Ok(())
     }
@@ -322,7 +323,7 @@ where
         self.write_governance_header(writer)?;
         // Payload ID
         writer.write_u16::<BigEndian>(self.chain)?;
-        writer.write(&self.endpoint_address[..])?;
+        writer.write_all(&self.endpoint_address[..])?;
 
         Ok(())
     }
@@ -337,7 +338,7 @@ pub struct GovernancePayloadUpgrade {
 impl SerializePayload for GovernancePayloadUpgrade {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
         self.write_governance_header(v)?;
-        v.write(&self.new_contract.to_bytes())?;
+        v.write_all(&self.new_contract.to_bytes())?;
         Ok(())
     }
 }

--- a/solana/modules/token_bridge/program/src/messages.rs
+++ b/solana/modules/token_bridge/program/src/messages.rs
@@ -1,8 +1,6 @@
-use crate::{
-    types::{
-        Address,
-        ChainID,
-    },
+use crate::types::{
+    Address,
+    ChainID,
 };
 use bridge::{
     vaa::{
@@ -23,11 +21,14 @@ use solana_program::{
     pubkey::Pubkey,
 };
 use solitaire::SolitaireError;
-use std::io::{
+use std::{
+    cmp,
+    io::{
         Cursor,
         Read,
         Write,
-    };
+    },
+};
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct PayloadTransfer {
@@ -250,7 +251,6 @@ impl DeserializePayload for PayloadAssetMeta {
 }
 
 impl SerializePayload for PayloadAssetMeta {
-    #[allow(clippy::manual_memcpy)]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SolitaireError> {
         // Payload ID
         writer.write_u8(2)?;
@@ -261,15 +261,15 @@ impl SerializePayload for PayloadAssetMeta {
         writer.write_u8(self.decimals)?;
 
         let mut symbol: [u8; 32] = [0; 32];
-        for i in 0..self.symbol.len() {
-            symbol[i] = self.symbol.as_bytes()[i];
-        }
+        let count = cmp::min(symbol.len(), self.symbol.len());
+        symbol[..count].copy_from_slice(self.symbol[..count].as_bytes());
+
         writer.write_all(&symbol)?;
 
         let mut name: [u8; 32] = [0; 32];
-        for i in 0..self.name.len() {
-            name[i] = self.name.as_bytes()[i];
-        }
+        let count = cmp::min(name.len(), self.name.len());
+        name[..count].copy_from_slice(self.name[..count].as_bytes());
+
         writer.write_all(&name)?;
 
         Ok(())

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -37,7 +37,6 @@ impl Owned for Config {
 #[cfg(feature = "cpi")]
 impl Owned for Config {
     fn owner(&self) -> AccountOwner {
-        use solana_program::pubkey::Pubkey;
         use std::str::FromStr;
         AccountOwner::Other(Pubkey::from_str(env!("TOKEN_BRIDGE_ADDRESS")).unwrap())
     }
@@ -59,7 +58,6 @@ impl Owned for EndpointRegistration {
 #[cfg(feature = "cpi")]
 impl Owned for EndpointRegistration {
     fn owner(&self) -> AccountOwner {
-        use solana_program::pubkey::Pubkey;
         use std::str::FromStr;
         AccountOwner::Other(Pubkey::from_str(env!("TOKEN_BRIDGE_ADDRESS")).unwrap())
     }
@@ -82,7 +80,6 @@ impl Owned for WrappedMeta {
 #[cfg(feature = "cpi")]
 impl Owned for WrappedMeta {
     fn owner(&self) -> AccountOwner {
-        use solana_program::pubkey::Pubkey;
         use std::str::FromStr;
         AccountOwner::Other(Pubkey::from_str(env!("TOKEN_BRIDGE_ADDRESS")).unwrap())
     }

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -18,7 +18,6 @@ use spl_token::state::{
     Account,
     Mint,
 };
-use spl_token_metadata::state::Metadata;
 
 pub type Address = [u8; 32];
 pub type ChainID = u16;

--- a/solana/modules/token_bridge/program/tests/common.rs
+++ b/solana/modules/token_bridge/program/tests/common.rs
@@ -159,6 +159,7 @@ mod helpers {
 
     /// Wait for a single transaction to fully finalize, guaranteeing chain state has been
     /// confirmed. Useful for consistently fetching data during state checks.
+    #[allow(dead_code)]
     pub async fn sync(client: &mut BanksClient, payer: &Keypair) {
         let payer_key = payer.pubkey();
         execute(
@@ -186,6 +187,7 @@ mod helpers {
     }
 
     /// Fetch account balance
+    #[allow(dead_code)]
     pub async fn get_account_balance(client: &mut BanksClient, account: Pubkey) -> u64 {
         client.get_account(account).await.unwrap().unwrap().lamports
     }
@@ -213,6 +215,7 @@ mod helpers {
         .await
     }
 
+    #[allow(dead_code)]
     pub async fn transfer(
         client: &mut BanksClient,
         from: &Keypair,
@@ -784,6 +787,7 @@ mod helpers {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)]
     pub async fn post_message(
         client: &mut BanksClient,
         program: Pubkey,

--- a/solana/modules/token_bridge/program/tests/common.rs
+++ b/solana/modules/token_bridge/program/tests/common.rs
@@ -1,35 +1,22 @@
-#![allow(warnings)]
-
 use borsh::{
     BorshDeserialize,
-    BorshSerialize,
 };
 use byteorder::{
     BigEndian,
     WriteBytesExt,
 };
-use hex_literal::hex;
 use libsecp256k1::{
-    Message as Secp256k1Message,
     PublicKey,
     SecretKey,
 };
 use sha3::Digest;
 use solana_program::{
-    borsh::try_from_slice_unchecked,
-    hash,
     instruction::{
-        AccountMeta,
         Instruction,
     },
     program_pack::Pack,
     pubkey::Pubkey,
-    system_instruction::{
-        self,
-        create_account,
-    },
-    system_program,
-    sysvar,
+    system_instruction,
 };
 use solana_program_test::{
     BanksClient,
@@ -40,40 +27,29 @@ use solana_sdk::{
     rent::Rent,
     secp256k1_instruction::new_secp256k1_instruction,
     signature::{
-        read_keypair_file,
         Keypair,
-        Signature,
         Signer,
     },
     signers::Signers,
     transaction::Transaction,
     transport::TransportError,
 };
-use spl_token::state::Mint;
 use std::{
-    convert::TryInto,
     env,
     io::{
         Cursor,
         Write,
     },
-    time::{
-        Duration,
-        SystemTime,
-    },
+    time::SystemTime,
 };
 
 use token_bridge::{
-    accounts::*,
-    instruction,
     instructions,
     types::*,
-    Initialize,
 };
 
 use solitaire::{
     processors::seeded::Seeded,
-    AccountState,
 };
 
 pub use helpers::*;
@@ -99,11 +75,9 @@ mod helpers {
     use bridge::{
         accounts::{
             FeeCollector,
-            PostedVAADerivationData,
         },
         types::ConsistencyLevel,
         PostVAAData,
-        PostedVAAData,
     };
     use solana_program_test::processor;
     use token_bridge::{
@@ -115,7 +89,6 @@ mod helpers {
         TransferWrappedData,
     };
 
-    use std::ops::Add;
     use token_bridge::messages::{
         PayloadAssetMeta,
         PayloadGovernanceRegisterChain,
@@ -125,8 +98,6 @@ mod helpers {
     /// Generate `count` secp256k1 private keys, along with their ethereum-styled public key
     /// encoding: 0x0123456789ABCDEF01234
     pub fn generate_keys(count: u8) -> (Vec<[u8; 20]>, Vec<SecretKey>) {
-        use rand::Rng;
-        use sha3::Digest;
 
         let mut rng = rand::thread_rng();
 
@@ -139,9 +110,9 @@ mod helpers {
             secret_keys
                 .iter()
                 .map(|key| {
-                    let public_key = PublicKey::from_secret_key(&key);
+                    let public_key = PublicKey::from_secret_key(key);
                     let mut h = sha3::Keccak256::default();
-                    h.write(&public_key.serialize()[1..]).unwrap();
+                    h.write_all(&public_key.serialize()[1..]).unwrap();
                     let key: [u8; 32] = h.finalize().into();
                     let mut address = [0u8; 20];
                     address.copy_from_slice(&key[12..]);
@@ -157,11 +128,11 @@ mod helpers {
     pub async fn setup() -> (BanksClient, Keypair, Pubkey, Pubkey) {
         let (program, token_program) = (
             env::var("BRIDGE_PROGRAM")
-                .unwrap_or("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o".to_string())
+                .unwrap_or_else(|_| "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o".to_string())
                 .parse::<Pubkey>()
                 .unwrap(),
             env::var("TOKEN_BRIDGE_PROGRAM")
-                .unwrap_or("B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE".to_string())
+                .unwrap_or_else(|_| "B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE".to_string())
                 .parse::<Pubkey>()
                 .unwrap(),
         );
@@ -290,12 +261,6 @@ mod helpers {
         mint: Pubkey,
         nonce: u32,
     ) -> Result<(), TransportError> {
-        let account = client
-            .get_account_with_commitment(mint, CommitmentLevel::Finalized)
-            .await?
-            .expect("mint account not found");
-        let mint_data = Mint::unpack(&account.data).expect("Could not unpack Mint");
-
         let instruction = instructions::attest(
             program,
             bridge,
@@ -320,6 +285,7 @@ mod helpers {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn transfer_native(
         client: &mut BanksClient,
         program: Pubkey,
@@ -373,6 +339,7 @@ mod helpers {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn transfer_wrapped(
         client: &mut BanksClient,
         program: Pubkey,
@@ -604,6 +571,7 @@ mod helpers {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_spl_metadata(
         client: &mut BanksClient,
         payer: &Keypair,
@@ -705,7 +673,7 @@ mod helpers {
         nonce: u32,
         sequence: u64,
     ) -> (PostVAAData, [u8; 32], [u8; 32]) {
-        let mut vaa = PostVAAData {
+        let vaa = PostVAAData {
             version: 0,
             guardian_set_index: 0,
 
@@ -728,10 +696,10 @@ mod helpers {
             v.write_u32::<BigEndian>(vaa.timestamp).unwrap();
             v.write_u32::<BigEndian>(vaa.nonce).unwrap();
             v.write_u16::<BigEndian>(vaa.emitter_chain).unwrap();
-            v.write(&vaa.emitter_address).unwrap();
+            v.write_all(&vaa.emitter_address).unwrap();
             v.write_u64::<BigEndian>(vaa.sequence).unwrap();
             v.write_u8(vaa.consistency_level).unwrap();
-            v.write(&vaa.payload).unwrap();
+            v.write_all(&vaa.payload).unwrap();
             v.into_inner()
         };
 
@@ -739,13 +707,13 @@ mod helpers {
         // signature account, binding that set of signatures to this VAA.
         let body: [u8; 32] = {
             let mut h = sha3::Keccak256::default();
-            h.write(body.as_slice()).unwrap();
+            h.write_all(body.as_slice()).unwrap();
             h.finalize().into()
         };
 
         let body_hash: [u8; 32] = {
             let mut h = sha3::Keccak256::default();
-            h.write(&body).unwrap();
+            h.write_all(&body).unwrap();
             h.finalize().into()
         };
 
@@ -815,6 +783,7 @@ mod helpers {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn post_message(
         client: &mut BanksClient,
         program: Pubkey,

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -1,63 +1,19 @@
 #![allow(warnings)]
-
-use borsh::BorshSerialize;
 use bridge::{
     accounts::{
-        Bridge,
-        FeeCollector,
-        GuardianSet,
-        GuardianSetDerivationData,
         PostedVAA,
         PostedVAADerivationData,
-        SignatureSet,
     },
-    instruction,
-    types::{
-        GovernancePayloadGuardianSetChange,
-        GovernancePayloadSetMessageFee,
-        GovernancePayloadTransferFees,
-    },
-    BridgeConfig,
-    BridgeData,
-    GuardianSetData,
-    Initialize,
-    MessageData,
-    PostVAA,
-    PostVAAData,
-    PostedVAAData,
-    SequenceTracker,
     SerializePayload,
-    Signature,
-    SignatureSet as SignatureSetData,
 };
-use byteorder::{
-    BigEndian,
-    WriteBytesExt,
-};
-use hex_literal::hex;
 use libsecp256k1::{
-    Message as Secp256k1Message,
-    PublicKey,
     SecretKey,
 };
 use primitive_types::U256;
 use rand::Rng;
-use sha3::Digest;
 use solana_program::{
-    borsh::try_from_slice_unchecked,
-    hash,
-    instruction::{
-        AccountMeta,
-        Instruction,
-    },
     program_pack::Pack,
     pubkey::Pubkey,
-    system_instruction::{
-        self,
-        create_account,
-    },
-    system_program,
-    sysvar,
 };
 use solana_program_test::{
     tokio,
@@ -66,11 +22,9 @@ use solana_program_test::{
 use solana_sdk::{
     commitment_config::CommitmentLevel,
     signature::{
-        read_keypair_file,
         Keypair,
         Signer,
     },
-    transaction::Transaction,
     transport::TransportError,
 };
 use solitaire::{
@@ -80,22 +34,11 @@ use solitaire::{
 use spl_token::state::Mint;
 use std::{
     collections::HashMap,
-    convert::TryInto,
-    io::{
-        Cursor,
-        Write,
-    },
     str::FromStr,
-    time::{
-        Duration,
-        SystemTime,
-        UNIX_EPOCH,
-    },
 };
 use token_bridge::{
     accounts::{
         ConfigAccount,
-        EmitterAccount,
         WrappedDerivationData,
         WrappedMint,
     },
@@ -105,7 +48,6 @@ use token_bridge::{
         PayloadTransfer,
     },
     types::{
-        Address,
         Config,
     },
 };
@@ -190,7 +132,7 @@ async fn set_up() -> Result<Context, TransportError> {
         mint_pubkey.as_ref(),
     ];
 
-    let (metadata_key, metadata_bump_seed) = Pubkey::find_program_address(
+    let (metadata_key, _metadata_bump_seed) = Pubkey::find_program_address(
         metadata_seeds,
         &Pubkey::from_str("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s").unwrap(),
     );
@@ -278,11 +220,11 @@ async fn create_wrapped(context: &mut Context) -> Pubkey {
         ref mut client,
         ref bridge,
         ref token_bridge,
-        ref mint_authority,
-        ref mint,
-        ref mint_meta,
-        ref token_account,
-        ref token_authority,
+        mint_authority: _,
+        mint: _,
+        mint_meta: _,
+        token_account: _,
+        token_authority: _,
         ..
     } = context;
 
@@ -305,7 +247,7 @@ async fn create_wrapped(context: &mut Context) -> Pubkey {
     common::post_vaa(client, *bridge, payer, signature_set, vaa.clone())
         .await
         .unwrap();
-    let mut msg_derivation_data = &PostedVAADerivationData {
+    let msg_derivation_data = &PostedVAADerivationData {
         payload_hash: body.to_vec(),
     };
     let message_key =
@@ -367,10 +309,10 @@ async fn attest() {
         ref mut client,
         bridge,
         token_bridge,
-        ref mint_authority,
+        mint_authority: _,
         ref mint,
-        ref mint_meta,
-        ref metadata_account,
+        mint_meta: _,
+        metadata_account: _,
         ..
     } = set_up().await.unwrap();
 
@@ -388,7 +330,6 @@ async fn attest() {
     .await
     .unwrap();
 
-    let emitter_key = EmitterAccount::key(None, &token_bridge);
     let account = client
         .get_account_with_commitment(mint.pubkey(), CommitmentLevel::Processed)
         .await
@@ -402,7 +343,6 @@ async fn attest() {
         symbol: "USD".to_string(),
         name: "Bitcoin".to_string(),
     };
-    let payload = payload.try_to_vec().unwrap();
 }
 
 #[tokio::test]
@@ -467,7 +407,7 @@ async fn register_chain(context: &mut Context) {
         .await
         .unwrap();
 
-    let mut msg_derivation_data = &PostedVAADerivationData {
+    let msg_derivation_data = &PostedVAADerivationData {
         payload_hash: body.to_vec(),
     };
     let message_key =

--- a/solana/modules/token_bridge/token-metadata/src/lib.rs
+++ b/solana/modules/token_bridge/token-metadata/src/lib.rs
@@ -1,5 +1,5 @@
-#![allow(warnings)]
-
+// The solana_program::declare_id! macro generates spurious import statements.
+#![allow(unused_imports)]
 pub mod instruction;
 pub mod state;
 pub mod utils;

--- a/solana/modules/token_bridge/token-metadata/src/lib.rs
+++ b/solana/modules/token_bridge/token-metadata/src/lib.rs
@@ -1,5 +1,5 @@
 // The solana_program::declare_id! macro generates spurious import statements.
-#![allow(unused_imports)]
+#[allow(unused_imports)]
 pub mod instruction;
 pub mod state;
 pub mod utils;

--- a/solana/modules/token_bridge/token-metadata/src/state.rs
+++ b/solana/modules/token_bridge/token-metadata/src/state.rs
@@ -5,8 +5,6 @@ use borsh::{
 };
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint::ProgramResult,
-    program_error::ProgramError,
     pubkey::Pubkey,
 };
 

--- a/solana/modules/token_bridge/token-metadata/src/utils.rs
+++ b/solana/modules/token_bridge/token-metadata/src/utils.rs
@@ -1,56 +1,12 @@
 use crate::state::{
-    Data,
     Key,
-    Metadata,
-    EDITION,
-    EDITION_MARKER_BIT_SIZE,
-    MAX_CREATOR_LIMIT,
-    MAX_EDITION_LEN,
-    MAX_EDITION_MARKER_SIZE,
-    MAX_MASTER_EDITION_LEN,
-    MAX_METADATA_LEN,
-    MAX_NAME_LENGTH,
-    MAX_SYMBOL_LENGTH,
-    MAX_URI_LENGTH,
-    PREFIX,
 };
 use borsh::{
     BorshDeserialize,
-    BorshSerialize,
 };
 use solana_program::{
-    account_info::AccountInfo,
     borsh::try_from_slice_unchecked,
-    entrypoint::ProgramResult,
-    msg,
-    program::{
-        invoke,
-        invoke_signed,
-    },
-    program_error::ProgramError,
-    program_option::COption,
-    program_pack::{
-        IsInitialized,
-        Pack,
-    },
-    pubkey::Pubkey,
-    system_instruction,
-    sysvar::{
-        rent::Rent,
-        Sysvar,
-    },
 };
-use spl_token::{
-    instruction::{
-        set_authority,
-        AuthorityType,
-    },
-    state::{
-        Account,
-        Mint,
-    },
-};
-use std::convert::TryInto;
 
 pub fn try_from_slice_checked<T: BorshDeserialize>(
     data: &[u8],

--- a/solana/solitaire/client/src/lib.rs
+++ b/solana/solitaire/client/src/lib.rs
@@ -1,7 +1,7 @@
 
+#![allow(incomplete_features)]
 #![feature(adt_const_params)]
 #![feature(const_generics_defaults)]
-#![allow(warnings)]
 
 //! Client-specific code
 
@@ -106,7 +106,7 @@ where
         match a {
             Signer(pair) => Ok(vec![AccountMeta::new(pair.pubkey(), true)]),
             SignerRO(pair) => Ok(vec![AccountMeta::new_readonly(pair.pubkey(), true)]),
-            other => Err(format!(
+            _other => Err(format!(
                 "{} must be passed as Signer or SignerRO",
                 std::any::type_name::<Self>()
             )
@@ -115,7 +115,7 @@ where
     }
 }
 
-impl<'a, 'b: 'a, T, const Seed: &'static str> Wrap for Derive<T, Seed> {
+impl<'a, 'b: 'a, T, const SEED: &'static str> Wrap for Derive<T, SEED> {
     fn wrap(a: &AccEntry) -> StdResult<Vec<AccountMeta>, ErrBox> {
         match a {
             AccEntry::Derived(program_id) => {
@@ -128,7 +128,7 @@ impl<'a, 'b: 'a, T, const Seed: &'static str> Wrap for Derive<T, Seed> {
 
                 Ok(vec![AccountMeta::new_readonly(k, false)])
             }
-            other => Err(format!(
+            _other => Err(format!(
                 "{} must be passed as Derived or DerivedRO",
                 std::any::type_name::<Self>()
             )
@@ -137,14 +137,14 @@ impl<'a, 'b: 'a, T, const Seed: &'static str> Wrap for Derive<T, Seed> {
     }
 }
 
-impl<'a, T, const IsInitialized: AccountState> Wrap for Data<'a, T, IsInitialized>
+impl<'a, T, const IS_INITIALIZED: AccountState> Wrap for Data<'a, T, IS_INITIALIZED>
 where
     T: BorshSerialize + Owned + Default,
 {
     fn wrap(a: &AccEntry) -> StdResult<Vec<AccountMeta>, ErrBox> {
         use AccEntry::*;
         use AccountState::*;
-        match IsInitialized {
+        match IS_INITIALIZED {
             Initialized => match a {
                 Unprivileged(k) => Ok(vec![AccountMeta::new(*k, false)]),
                 UnprivilegedRO(k) => Ok(vec![AccountMeta::new_readonly(*k, false)]),
@@ -173,7 +173,7 @@ where
     fn wrap(a: &AccEntry) -> StdResult<Vec<AccountMeta>, ErrBox> {
         if let AccEntry::Sysvar(k) = a {
             if Var::check_id(k) {
-                Ok(vec![AccountMeta::new_readonly(k.clone(), false)])
+                Ok(vec![AccountMeta::new_readonly(*k, false)])
             } else {
                 Err(format!(
                     "{} does not point at sysvar {}",
@@ -191,8 +191,8 @@ where
 impl<'b> Wrap for Info<'b> {
     fn wrap(a: &AccEntry) -> StdResult<Vec<AccountMeta>, ErrBox> {
         match a {
-            AccEntry::UnprivilegedRO(k) => Ok(vec![AccountMeta::new_readonly(k.clone(), false)]),
-            AccEntry::Unprivileged(k) => Ok(vec![AccountMeta::new(k.clone(), false)]),
+            AccEntry::UnprivilegedRO(k) => Ok(vec![AccountMeta::new_readonly(*k, false)]),
+            AccEntry::Unprivileged(k) => Ok(vec![AccountMeta::new(*k, false)]),
             _other => Err(format!(
                 "{} must be passed as Unprivileged or UnprivilegedRO",
                 std::any::type_name::<Self>()

--- a/solana/solitaire/program/src/error.rs
+++ b/solana/solitaire/program/src/error.rs
@@ -64,10 +64,11 @@ impl From<std::io::Error> for SolitaireError {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<ProgramError> for SolitaireError {
     fn into(self) -> ProgramError {
         match self {
-            SolitaireError::ProgramError(e) => return e,
+            SolitaireError::ProgramError(e) => e,
             _ => ProgramError::Custom(0),
         }
     }

--- a/solana/solitaire/program/src/error.rs
+++ b/solana/solitaire/program/src/error.rs
@@ -64,10 +64,9 @@ impl From<std::io::Error> for SolitaireError {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<ProgramError> for SolitaireError {
-    fn into(self) -> ProgramError {
-        match self {
+impl From<SolitaireError> for ProgramError {
+    fn from(err: SolitaireError) -> ProgramError {
+        match err {
             SolitaireError::ProgramError(e) => e,
             _ => ProgramError::Custom(0),
         }

--- a/solana/solitaire/program/src/lib.rs
+++ b/solana/solitaire/program/src/lib.rs
@@ -1,6 +1,6 @@
 
+#![allow(incomplete_features)]
 #![feature(adt_const_params)]
-#![allow(warnings)]
 
 pub use rocksalt::*;
 
@@ -11,42 +11,12 @@ pub use rocksalt::*;
 
 // We need a few Solana things in scope in order to properly abstract Solana.
 use solana_program::{
-    account_info::{
-        next_account_info,
-        AccountInfo,
-    },
-    entrypoint,
-    entrypoint::ProgramResult,
-    instruction::{
-        AccountMeta,
-        Instruction,
-    },
-    program::invoke_signed,
-    program_error::ProgramError,
-    program_pack::Pack,
+    account_info::AccountInfo,
     pubkey::Pubkey,
     rent::Rent,
-    system_instruction,
-    system_program,
-    sysvar::{
-        self,
-        SysvarId,
-    },
 };
 
-use std::{
-    io::{
-        ErrorKind,
-        Write,
-    },
-    marker::PhantomData,
-    ops::{
-        Deref,
-        DerefMut,
-    },
-    slice::Iter,
-    string::FromUtf8Error,
-};
+use std::slice::Iter;
 
 pub use borsh::{
     BorshDeserialize,
@@ -85,7 +55,7 @@ pub use crate::{
 };
 
 /// Library name and version to print in entrypoint. Must be evaluated in this crate in order to do the right thing
-pub const PKG_NAME_VERSION: &'static str =
+pub const PKG_NAME_VERSION: &str =
     concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
 
 pub struct ExecutionContext<'a, 'b: 'a> {

--- a/solana/solitaire/program/src/macros.rs
+++ b/solana/solitaire/program/src/macros.rs
@@ -1,8 +1,3 @@
-use std::ops::{
-    Deref,
-    DerefMut,
-};
-
 /// A wrapper around Solana's `msg!` macro that is a no-op by default, allows for adding traces
 /// through the application that can be toggled during tests.
 #[macro_export]
@@ -137,7 +132,7 @@ macro_rules! pack_type {
             fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                 let mut data = [0u8; <$embed as solana_program::program_pack::Pack>::LEN];
                 solana_program::program_pack::Pack::pack_into_slice(&self.0, &mut data);
-                writer.write(&data)?;
+                writer.write_all(&data)?;
 
                 Ok(())
             }

--- a/solana/solitaire/program/src/processors/keyed.rs
+++ b/solana/solitaire/program/src/processors/keyed.rs
@@ -1,7 +1,4 @@
-use solana_program::{
-    pubkey::Pubkey,
-    sysvar::Sysvar as SolanaSysvar,
-};
+use solana_program::sysvar::Sysvar as SolanaSysvar;
 
 use crate::{
     processors::seeded::Owned,
@@ -19,8 +16,8 @@ pub trait Keyed<'a, 'b: 'a> {
     fn info(&'a self) -> &Info<'b>;
 }
 
-impl<'a, 'b: 'a, T: Owned + Default, const IsInitialized: AccountState> Keyed<'a, 'b>
-    for Data<'b, T, IsInitialized>
+impl<'a, 'b: 'a, T: Owned + Default, const IS_INITIALIZED: AccountState> Keyed<'a, 'b>
+    for Data<'b, T, IS_INITIALIZED>
 {
     fn info(&'a self) -> &'a Info<'b> {
         &self.0
@@ -51,7 +48,7 @@ where
     }
 }
 
-impl<'a, 'b: 'a, T, const Seed: &'static str> Keyed<'a, 'b> for Derive<T, Seed>
+impl<'a, 'b: 'a, T, const SEED: &'static str> Keyed<'a, 'b> for Derive<T, SEED>
 where
     T: Keyed<'a, 'b>,
 {

--- a/solana/solitaire/program/src/types/accounts.rs
+++ b/solana/solitaire/program/src/types/accounts.rs
@@ -7,7 +7,6 @@
 use borsh::BorshSerialize;
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint::ProgramResult,
     program::{
         invoke,
         invoke_signed,
@@ -28,7 +27,6 @@ use crate::{
     ExecutionContext,
     Keyed,
     Result,
-    SolitaireError,
 };
 
 /// A short alias for AccountInfo.
@@ -85,13 +83,13 @@ use IsSigned::*;
 ///
 /// Data<(), { AccountState::Uninitialized }>
 #[rustfmt::skip]
-pub struct Data<'r, T: Owned + Default, const IsInitialized: AccountState> (
+pub struct Data<'r, T: Owned + Default, const IS_INITIALIZED: AccountState> (
     pub Box<Info<'r>>,
     pub T,
 );
 
-impl<'r, T: Owned + Default, const IsInitialized: AccountState> Deref
-    for Data<'r, T, IsInitialized>
+impl<'r, T: Owned + Default, const IS_INITIALIZED: AccountState> Deref
+    for Data<'r, T, IS_INITIALIZED>
 {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -99,8 +97,8 @@ impl<'r, T: Owned + Default, const IsInitialized: AccountState> Deref
     }
 }
 
-impl<'r, T: Owned + Default, const IsInitialized: AccountState> DerefMut
-    for Data<'r, T, IsInitialized>
+impl<'r, T: Owned + Default, const IS_INITIALIZED: AccountState> DerefMut
+    for Data<'r, T, IS_INITIALIZED>
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.1
@@ -123,7 +121,7 @@ impl<'b, Var: SolanaSysvar> Deref for Sysvar<'b, Var> {
     }
 }
 
-impl<const Seed: &'static str> Derive<AccountInfo<'_>, Seed> {
+impl<const SEED: &'static str> Derive<AccountInfo<'_>, SEED> {
     pub fn create(
         &self,
         ctx: &ExecutionContext,
@@ -132,7 +130,7 @@ impl<const Seed: &'static str> Derive<AccountInfo<'_>, Seed> {
         space: usize,
         owner: &Pubkey,
     ) -> Result<()> {
-        let (_, bump_seed) = Pubkey::find_program_address(&[Seed.as_bytes()][..], ctx.program_id);
+        let (_, bump_seed) = Pubkey::find_program_address(&[SEED.as_bytes()][..], ctx.program_id);
         create_account(
             ctx,
             self.info(),
@@ -140,13 +138,13 @@ impl<const Seed: &'static str> Derive<AccountInfo<'_>, Seed> {
             lamports,
             space,
             owner,
-            SignedWithSeeds(&[&[Seed.as_bytes(), &[bump_seed]]]),
+            SignedWithSeeds(&[&[SEED.as_bytes(), &[bump_seed]]]),
         )
     }
 }
 
-impl<const Seed: &'static str, T: BorshSerialize + Owned + Default>
-    Derive<Data<'_, T, { AccountState::Uninitialized }>, Seed>
+impl<const SEED: &'static str, T: BorshSerialize + Owned + Default>
+    Derive<Data<'_, T, { AccountState::Uninitialized }>, SEED>
 {
     pub fn create(
         &self,
@@ -156,7 +154,7 @@ impl<const Seed: &'static str, T: BorshSerialize + Owned + Default>
     ) -> Result<()> {
         // Get serialized struct size
         let size = self.0.try_to_vec().unwrap().len();
-        let (_, bump_seed) = Pubkey::find_program_address(&[Seed.as_bytes()][..], ctx.program_id);
+        let (_, bump_seed) = Pubkey::find_program_address(&[SEED.as_bytes()][..], ctx.program_id);
         create_account(
             ctx,
             self.info(),
@@ -164,7 +162,7 @@ impl<const Seed: &'static str, T: BorshSerialize + Owned + Default>
             lamports,
             size,
             ctx.program_id,
-            SignedWithSeeds(&[&[Seed.as_bytes(), &[bump_seed]]]),
+            SignedWithSeeds(&[&[SEED.as_bytes(), &[bump_seed]]]),
         )
     }
 }

--- a/solana/solitaire/program/src/types/layers.rs
+++ b/solana/solitaire/program/src/types/layers.rs
@@ -6,21 +6,10 @@
 //! the layer below, allowing for optimized recursion.
 
 use std::{
-    io::{
-        ErrorKind,
-        Write,
-    },
-    marker::PhantomData,
     ops::{
         Deref,
         DerefMut,
     },
-};
-
-use crate::Info;
-use borsh::{
-    BorshDeserialize,
-    BorshSerialize,
 };
 
 #[repr(transparent)]
@@ -36,7 +25,7 @@ pub struct Signer<Next>(pub Next);
 pub struct System<Next>(pub Next);
 
 #[repr(transparent)]
-pub struct Derive<Next, const Seed: &'static str>(pub Next);
+pub struct Derive<Next, const SEED: &'static str>(pub Next);
 
 // Several traits are required for types defined here, they cannot be defined in another file due
 // to orphan instance limitations.
@@ -93,14 +82,14 @@ impl<T> DerefMut for System<T> {
     }
 }
 
-impl<T, const Seed: &'static str> Deref for Derive<T, Seed> {
+impl<T, const SEED: &'static str> Deref for Derive<T, SEED> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         unsafe { std::mem::transmute(&self.0) }
     }
 }
 
-impl<T, const Seed: &'static str> DerefMut for Derive<T, Seed> {
+impl<T, const SEED: &'static str> DerefMut for Derive<T, SEED> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { std::mem::transmute(&mut self.0) }
     }

--- a/solana/solitaire/rocksalt/src/lib.rs
+++ b/solana/solitaire/rocksalt/src/lib.rs
@@ -1,41 +1,61 @@
-#![allow(warnings)]
-
 mod to_instruction;
 
 use to_instruction::*;
 
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-
 use proc_macro::TokenStream;
-use proc_macro2::{
-    Span,
-    TokenStream as TokenStream2,
-};
-use quote::{
-    quote,
-    quote_spanned,
-    ToTokens,
-};
-use std::borrow::BorrowMut;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
 use syn::{
     parse_macro_input,
     parse_quote,
-    spanned::Spanned,
     Data,
     DeriveInput,
     Fields,
     GenericParam,
     Generics,
-    Index,
 };
 
 #[proc_macro_derive(ToInstruction)]
 pub fn derive_to_instruction(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    // Type params of the instruction context account
+    let type_params: Vec<GenericParam> = input
+        .generics
+        .type_params()
+        .map(|v| GenericParam::Type(v.clone()))
+        .collect();
+
+    // Generics lifetimes of the peel type
+    let mut peel_g = input.generics.clone();
+    peel_g.params = parse_quote!('a, 'b: 'a, 'c);
+
+    // Params of the instruction context
+    let mut type_generics = input.generics.clone();
+    type_generics.params = parse_quote!('b);
+    for x in &type_params {
+        type_generics.params.push(x.clone());
+    }
+
+    // Combined lifetimes of peel and the instruction context
+    let mut combined_generics = Generics {
+        params: peel_g.params,
+        ..Default::default()
+    };
+    for x in &type_params {
+        combined_generics.params.push(x.clone());
+    }
+    let (combined_impl_g, _, _) = combined_generics.split_for_impl();
+
+    let expanded = generate_to_instruction(&name, &combined_impl_g, &input.data);
+    TokenStream::from(expanded)
+}
+
+/// Generate a FromAccounts implementation for a product of accounts. Each field is constructed by
+/// a call to the Verify::verify instance of its type.
+#[proc_macro_derive(FromAccounts)]
+pub fn derive_from_accounts(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
 
@@ -60,55 +80,18 @@ pub fn derive_to_instruction(input: TokenStream) -> TokenStream {
     let (type_impl_g, type_g, _) = type_generics.split_for_impl();
 
     // Combined lifetimes of peel and the instruction context
-    let mut combined_generics = Generics::default();
-    combined_generics.params = peel_g.params.clone();
-    for x in &type_params {
-        combined_generics.params.push(x.clone());
-    }
-    let (combined_impl_g, _, _) = combined_generics.split_for_impl();
-
-    let expanded = generate_to_instruction(&name, &combined_impl_g, &input.data);
-    TokenStream::from(expanded)
-}
-
-/// Generate a FromAccounts implementation for a product of accounts. Each field is constructed by
-/// a call to the Verify::verify instance of its type.
-#[proc_macro_derive(FromAccounts)]
-pub fn derive_from_accounts(input: TokenStream) -> TokenStream {
-    let mut input = parse_macro_input!(input as DeriveInput);
-    let name = input.ident;
-
-    // Type params of the instruction context account
-    let type_params: Vec<GenericParam> = input
-        .generics
-        .type_params()
-        .map(|v| GenericParam::Type(v.clone()))
-        .collect();
-
-    // Generics lifetimes of the peel type
-    let mut peel_g = input.generics.clone();
-    peel_g.params = parse_quote!('a, 'b: 'a, 'c);
-    let (_, peel_type_g, _) = peel_g.split_for_impl();
-
-    // Params of the instruction context
-    let mut type_generics = input.generics.clone();
-    type_generics.params = parse_quote!('b);
-    for x in &type_params {
-        type_generics.params.push(x.clone());
-    }
-    let (type_impl_g, type_g, _) = type_generics.split_for_impl();
-
-    // Combined lifetimes of peel and the instruction context
-    let mut combined_generics = Generics::default();
-    combined_generics.params = peel_g.params.clone();
+    let mut combined_generics = Generics {
+        params: peel_g.params.clone(),
+        ..Default::default()
+    };
     for x in &type_params {
         combined_generics.params.push(x.clone());
     }
     let (combined_impl_g, _, _) = combined_generics.split_for_impl();
 
     let from_method = generate_fields(&name, &input.data);
-    let persist_method = generate_persist(&name, &input.data);
-    let deps_method = generate_deps_fields(&name, &input.data);
+    let persist_method = generate_persist(&input.data);
+    let deps_method = generate_deps_fields(&input.data);
     let expanded = quote! {
         /// Macro generated implementation of FromAccounts by Solitaire.
         impl #combined_impl_g solitaire::FromAccounts #peel_type_g for #name #type_g {
@@ -201,7 +184,7 @@ fn generate_fields(name: &syn::Ident, data: &Data) -> TokenStream2 {
 }
 
 /// This function does the heavy lifting of generating the field parsers.
-fn generate_deps_fields(name: &syn::Ident, data: &Data) -> TokenStream2 {
+fn generate_deps_fields(data: &Data) -> TokenStream2 {
     match *data {
         // We only care about structures.
         Data::Struct(ref data) => {
@@ -240,7 +223,7 @@ fn generate_deps_fields(name: &syn::Ident, data: &Data) -> TokenStream2 {
 }
 
 /// This function does the heavy lifting of generating the field parsers.
-fn generate_persist(name: &syn::Ident, data: &Data) -> TokenStream2 {
+fn generate_persist(data: &Data) -> TokenStream2 {
     match *data {
         // We only care about structures.
         Data::Struct(ref data) => {
@@ -254,7 +237,6 @@ fn generate_persist(name: &syn::Ident, data: &Data) -> TokenStream2 {
                     let recurse = fields.named.iter().map(|f| {
                         // Field name, to assign to.
                         let name = &f.ident;
-                        let ty = &f.ty;
 
                         quote! {
                             trace!(stringify!(#name));

--- a/solana/solitaire/rocksalt/src/to_instruction.rs
+++ b/solana/solitaire/rocksalt/src/to_instruction.rs
@@ -1,25 +1,14 @@
 //! Derive macro logic for ToInstruction
 
-use proc_macro::TokenStream;
 use proc_macro2::{
     Span,
     TokenStream as TokenStream2,
 };
-use quote::{
-    quote,
-    quote_spanned,
-};
+use quote::quote;
 use syn::{
-    parse_macro_input,
-    parse_quote,
-    spanned::Spanned,
     Data,
     DataStruct,
-    DeriveInput,
     Fields,
-    GenericParam,
-    Generics,
-    Index,
 };
 
 pub fn generate_to_instruction(
@@ -45,9 +34,9 @@ pub fn generate_to_instruction(
                 }
             });
             let client_struct_name =
-                syn::Ident::new(&format!("{}Accounts", name.to_string()), Span::call_site());
+                syn::Ident::new(&format!("{}Accounts", name), Span::call_site());
 
-            let client_struct_decl = generate_clientside_struct(&name, &client_struct_name, &data);
+            let client_struct_decl = generate_clientside_struct(&client_struct_name, data);
 
             quote! {
             /// Solitaire-generated client-side #name representation
@@ -90,7 +79,6 @@ pub fn generate_to_instruction(
 }
 
 pub fn generate_clientside_struct(
-    name: &syn::Ident,
     client_struct_name: &syn::Ident,
     data: &Data,
 ) -> TokenStream2 {


### PR DESCRIPTION
`rustc` raises a lot of warnings when building the solana contracts. The first commit fixes them, most of them being redundant imports.
The second commit fixes all of the `clippy` hints. Most of them are about using `write_all` instead of `write` and spurious lifetime parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1226)
<!-- Reviewable:end -->
