### PR TITLE
spy_relayer: add karura token bridge emitter

### DIFF
--- a/relayer/spy_relayer/config/mainnet/emitterAddresses.json
+++ b/relayer/spy_relayer/config/mainnet/emitterAddresses.json
@@ -8,6 +8,7 @@
     {"chainId":7,"emitterAddress":"0x5848C791e09901b40A9Ef749f2a6735b418d7564"},
     {"chainId":9,"emitterAddress":"0x51b5123a7b0f9b2ba265f9c4c8de7d78d52f510f"},
     {"chainId":10,"emitterAddress":"0x7C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2"},
+    {"chainId":11,"emitterAddress":"0xae9d7fe007b3327AA64A32824Aaac52C42a6E624"},
     {"chainId":13,"emitterAddress":"0x5b08ac39EAED75c0439FC750d9FE7E1F9dD0193F"},
     {"chainId":14,"emitterAddress":"0x796Dff6D74F3E27060B71255Fe517BFb23C93eed"}
 ]


### PR DESCRIPTION
This way, the spy listener will filter for messages from that emitter.