### PR TITLE
Fix algorand attestation bug

### DIFF
--- a/algorand/token_bridge.py
+++ b/algorand/token_bridge.py
@@ -863,7 +863,7 @@ def approve_token_bridge(seed_amt: int, tmpl_sig: TmplSig, devMode: bool):
                    MagicAssert(Btoi(extract_decimal(aid.load())) <= Int(8)),
 
                    # Lets just hand back the previously generated vaa payload
-                   p.store(blob.read(Int(2), Int(8), Int(108)))
+                   p.store(blob.read(Int(2), Int(59), Int(159)))
                ]),
                Seq([
 #                   Log(Bytes("Non Wormhole wrapped")),


### PR DESCRIPTION

Malformed attestation when used against a previously created wormhole asset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1289)
<!-- Reviewable:end -->
