### PR TITLE
node/pkg/ethereum: fix a bug discovered in testnet

### DIFF
--- a/node/pkg/ethereum/pollimpl.go
+++ b/node/pkg/ethereum/pollimpl.go
@@ -244,7 +244,12 @@ func (e *PollImpl) getBlock(ctx context.Context, number *big.Int) (*common.NewBl
 			zap.String("requested_block", numStr), zap.Error(err))
 		return nil, err
 	}
-
+	if m.Number == nil {
+		e.logger.Error("failed to unmarshal block", zap.String("eth_network", e.BaseEth.NetworkName),
+			zap.String("requested_block", numStr),
+		)
+		return nil, fmt.Errorf("failed to unmarshal block: Number is nil")
+	}
 	n := big.Int(*m.Number)
 	return &common.NewBlock{
 		Number: &n,


### PR DESCRIPTION
We were getting a panic here: https://github.com/certusone/wormhole/blob/cdc6edd4255faa196bc993878e367f9fb617a8e3/node/pkg/ethereum/pollimpl.go#L248

Due to `m.Number` being nil.

```
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: panic: runtime error: invalid memory address or nil pointer dereference
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x149e750]
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: goroutine 709 [running]:
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: github.com/certusone/wormhole/node/pkg/ethereum.(*PollImpl).getBlock(0xc00f0f8660, {0x2fdfd10, 0xc00f0f4500}, 0x0)
Jun 24 15:39:27 [CENSORED] guardiand[2595664]:         /opt/wormhole/wormhole/node/pkg/ethereum/pollimpl.go:248 +0x490
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: github.com/certusone/wormhole/node/pkg/ethereum.(*PollImpl).SubscribeForBlocks.func1()
Jun 24 15:39:27 [CENSORED] guardiand[2595664]:         /opt/wormhole/wormhole/node/pkg/ethereum/pollimpl.go:183 +0xc57
Jun 24 15:39:27 [CENSORED] guardiand[2595664]: created by github.com/certusone/wormhole/node/pkg/ethereum.(*PollImpl).SubscribeForBlocks
Jun 24 15:39:27 [CENSORED] guardiand[2595664]:         /opt/wormhole/wormhole/node/pkg/ethereum/pollimpl.go:148 +0x29e
Jun 24 15:39:27 [CENSORED] systemd[1]: guardiand.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jun 24 15:39:27 [CENSORED] systemd[1]: guardiand.service: Failed with result 'exit-code'.
Jun 24 15:39:32 [CENSORED] systemd[1]: guardiand.service: Service RestartSec=5s expired, scheduling restart.
Jun 24 15:39:32 [CENSORED] systemd[1]: guardiand.service: Scheduled restart job, restart counter is at 176.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1304)
<!-- Reviewable:end -->
