### PR TITLE
node/pkg/common: Refactor KnownEmitters

### DIFF
--- a/node/pkg/common/devnet_consts.go
+++ b/node/pkg/common/devnet_consts.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"github.com/certusone/wormhole/node/pkg/vaa"
+)
+
+// KnownDevnetEmitters is a list of known emitters used during development.
+var KnownDevnetEmitters = buildKnownEmitters(knownDevnetTokenbridgeEmitters, knownDevnetNFTBridgeEmitters)
+
+// KnownDevnetTokenbridgeEmitters is a map of known tokenbridge emitters used during development.
+var KnownDevnetTokenbridgeEmitters = buildEmitterMap(knownDevnetTokenbridgeEmitters)
+var knownDevnetTokenbridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:   "c69a1b1a65dd336bf1df6a77afb501fc25db7fc0938cb08595a9ef473265cb4f",
+	vaa.ChainIDEthereum: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16",
+	vaa.ChainIDTerra:    "000000000000000000000000784999135aaa8a3ca5914468852fdddbddd8789d",
+	vaa.ChainIDBSC:      "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16",
+	vaa.ChainIDAlgorand: "8edf5b0e108c3a1a0a4b704cc89591f2ad8d50df24e991567e640ed720a94be2",
+}
+
+// KnownDevnetNFTBridgeEmitters is a map of known NFT emitters used during development.
+var KnownDevnetNFTBridgeEmitters = buildEmitterMap(knownDevnetNFTBridgeEmitters)
+var knownDevnetNFTBridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:   "96ee982293251b48729804c8e8b24b553eb6b887867024948d2236fd37a577ab",
+	vaa.ChainIDEthereum: "00000000000000000000000026b4afb60d6c903165150c6f0aa14f8016be4aec",
+	vaa.ChainIDBSC:      "00000000000000000000000026b4afb60d6c903165150c6f0aa14f8016be4aec",
+}

--- a/node/pkg/common/mainnet_consts.go
+++ b/node/pkg/common/mainnet_consts.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/certusone/wormhole/node/pkg/vaa"
@@ -46,41 +47,86 @@ func (et EmitterType) String() string {
 	}
 }
 
+type EmitterInfo struct {
+	ChainID    vaa.ChainID
+	Emitter    string
+	BridgeType EmitterType
+}
+
 // KnownEmitters is a list of well-known mainnet emitters we want to take into account
 // when iterating over all emitters - like for finding and repairing missing messages.
 //
 // Wormhole is not permissioned - anyone can use it. Adding contracts to this list is
 // entirely optional and at the core team's discretion.
 //
-var KnownEmitters = []struct {
-	ChainID    vaa.ChainID
-	Emitter    string
-	BridgeType EmitterType
-}{
-	{vaa.ChainIDSolana, "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5", EmitterTokenBridge},
-	{vaa.ChainIDSolana, "0def15a24423e1edd1a5ab16f557b9060303ddbab8c803d2ee48f4b78a1cfd6b", EmitterNFTBridge},
-	{vaa.ChainIDEthereum, "0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585", EmitterTokenBridge},
-	{vaa.ChainIDEthereum, "0000000000000000000000006ffd7ede62328b3af38fcd61461bbfc52f5651fe", EmitterNFTBridge},
-	{vaa.ChainIDTerra, "0000000000000000000000007cf7b764e38a0a5e967972c1df77d432510564e2", EmitterTokenBridge},
-	{vaa.ChainIDTerra2, "a463ad028fb79679cfc8ce1efba35ac0e77b35080a1abe9bebe83461f176b0a3", EmitterTokenBridge},
-	{vaa.ChainIDBSC, "000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7", EmitterTokenBridge},
-	{vaa.ChainIDBSC, "0000000000000000000000005a58505a96d1dbf8df91cb21b54419fc36e93fde", EmitterNFTBridge},
-	{vaa.ChainIDPolygon, "0000000000000000000000005a58505a96d1dbf8df91cb21b54419fc36e93fde", EmitterTokenBridge},
-	{vaa.ChainIDPolygon, "00000000000000000000000090bbd86a6fe93d3bc3ed6335935447e75fab7fcf", EmitterNFTBridge},
-	{vaa.ChainIDAvalanche, "0000000000000000000000000e082f06ff657d94310cb8ce8b0d9a04541d8052", EmitterTokenBridge},
-	{vaa.ChainIDAvalanche, "000000000000000000000000f7b6737ca9c4e08ae573f75a97b73d7a813f5de5", EmitterNFTBridge},
-	{vaa.ChainIDOasis, "0000000000000000000000005848c791e09901b40a9ef749f2a6735b418d7564", EmitterTokenBridge},
-	{vaa.ChainIDOasis, "00000000000000000000000004952d522ff217f40b5ef3cbf659eca7b952a6c1", EmitterNFTBridge},
-	{vaa.ChainIDAurora, "00000000000000000000000051b5123a7b0F9b2bA265f9c4C8de7D78D52f510F", EmitterTokenBridge},
-	{vaa.ChainIDAurora, "0000000000000000000000006dcC0484472523ed9Cdc017F711Bcbf909789284", EmitterNFTBridge},
-	{vaa.ChainIDFantom, "0000000000000000000000007C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2", EmitterTokenBridge},
-	{vaa.ChainIDFantom, "000000000000000000000000A9c7119aBDa80d4a4E0C06C8F4d8cF5893234535", EmitterNFTBridge},
-	{vaa.ChainIDKarura, "000000000000000000000000ae9d7fe007b3327AA64A32824Aaac52C42a6E624", EmitterTokenBridge},
-	{vaa.ChainIDKarura, "000000000000000000000000b91e3638F82A1fACb28690b37e3aAE45d2c33808", EmitterNFTBridge},
-	{vaa.ChainIDAcala, "000000000000000000000000ae9d7fe007b3327AA64A32824Aaac52C42a6E624", EmitterTokenBridge},
-	{vaa.ChainIDAcala, "000000000000000000000000b91e3638F82A1fACb28690b37e3aAE45d2c33808", EmitterNFTBridge},
-	{vaa.ChainIDKlaytn, "0000000000000000000000005b08ac39EAED75c0439FC750d9FE7E1F9dD0193F", EmitterTokenBridge},
-	{vaa.ChainIDKlaytn, "0000000000000000000000003c3c561757BAa0b78c5C025CdEAa4ee24C1dFfEf", EmitterNFTBridge},
-	{vaa.ChainIDCelo, "000000000000000000000000796Dff6D74F3E27060B71255Fe517BFb23C93eed", EmitterTokenBridge},
-	{vaa.ChainIDCelo, "000000000000000000000000A6A377d75ca5c9052c9a77ED1e865Cc25Bd97bf3", EmitterNFTBridge},
+var KnownEmitters = buildKnownEmitters(knownTokenbridgeEmitters, knownNFTBridgeEmitters)
+
+func buildKnownEmitters(tokenEmitters, nftEmitters map[vaa.ChainID]string) []EmitterInfo {
+	out := make([]EmitterInfo, 0, len(knownTokenbridgeEmitters)+len(knownNFTBridgeEmitters))
+	for id, emitter := range tokenEmitters {
+		out = append(out, EmitterInfo{
+			ChainID:    id,
+			Emitter:    emitter,
+			BridgeType: EmitterTokenBridge,
+		})
+	}
+
+	for id, emitter := range nftEmitters {
+		out = append(out, EmitterInfo{
+			ChainID:    id,
+			Emitter:    emitter,
+			BridgeType: EmitterNFTBridge,
+		})
+	}
+
+	return out
+}
+
+func buildEmitterMap(hexmap map[vaa.ChainID]string) map[vaa.ChainID][]byte {
+	out := make(map[vaa.ChainID][]byte)
+	for id, emitter := range hexmap {
+		e, err := hex.DecodeString(emitter)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to decode emitter address %v: %v", emitter, err))
+		}
+		out[id] = e
+	}
+
+	return out
+}
+
+// KnownTokenbridgeEmitters is a list of well-known mainnet emitters for the tokenbridge.
+var KnownTokenbridgeEmitters = buildEmitterMap(knownTokenbridgeEmitters)
+var knownTokenbridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:    "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+	vaa.ChainIDEthereum:  "0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585",
+	vaa.ChainIDTerra:     "0000000000000000000000007cf7b764e38a0a5e967972c1df77d432510564e2",
+	vaa.ChainIDTerra2:    "a463ad028fb79679cfc8ce1efba35ac0e77b35080a1abe9bebe83461f176b0a3",
+	vaa.ChainIDBSC:       "000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7",
+	vaa.ChainIDPolygon:   "0000000000000000000000005a58505a96d1dbf8df91cb21b54419fc36e93fde",
+	vaa.ChainIDAvalanche: "0000000000000000000000000e082f06ff657d94310cb8ce8b0d9a04541d8052",
+	vaa.ChainIDOasis:     "0000000000000000000000005848c791e09901b40a9ef749f2a6735b418d7564",
+	vaa.ChainIDAurora:    "00000000000000000000000051b5123a7b0F9b2bA265f9c4C8de7D78D52f510F",
+	vaa.ChainIDFantom:    "0000000000000000000000007C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2",
+	vaa.ChainIDKarura:    "000000000000000000000000ae9d7fe007b3327AA64A32824Aaac52C42a6E624",
+	vaa.ChainIDAcala:     "000000000000000000000000ae9d7fe007b3327AA64A32824Aaac52C42a6E624",
+	vaa.ChainIDKlaytn:    "0000000000000000000000005b08ac39EAED75c0439FC750d9FE7E1F9dD0193F",
+	vaa.ChainIDCelo:      "000000000000000000000000796Dff6D74F3E27060B71255Fe517BFb23C93eed",
+}
+
+// KnownNFTBridgeEmitters is a list of well-known mainnet emitters for the NFT bridge.
+var KnownNFTBridgeEmitters = buildEmitterMap(knownNFTBridgeEmitters)
+var knownNFTBridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:    "0def15a24423e1edd1a5ab16f557b9060303ddbab8c803d2ee48f4b78a1cfd6b",
+	vaa.ChainIDEthereum:  "0000000000000000000000006ffd7ede62328b3af38fcd61461bbfc52f5651fe",
+	vaa.ChainIDBSC:       "0000000000000000000000005a58505a96d1dbf8df91cb21b54419fc36e93fde",
+	vaa.ChainIDPolygon:   "00000000000000000000000090bbd86a6fe93d3bc3ed6335935447e75fab7fcf",
+	vaa.ChainIDAvalanche: "000000000000000000000000f7b6737ca9c4e08ae573f75a97b73d7a813f5de5",
+	vaa.ChainIDOasis:     "00000000000000000000000004952d522ff217f40b5ef3cbf659eca7b952a6c1",
+	vaa.ChainIDAurora:    "0000000000000000000000006dcC0484472523ed9Cdc017F711Bcbf909789284",
+	vaa.ChainIDFantom:    "000000000000000000000000A9c7119aBDa80d4a4E0C06C8F4d8cF5893234535",
+	vaa.ChainIDKarura:    "000000000000000000000000b91e3638F82A1fACb28690b37e3aAE45d2c33808",
+	vaa.ChainIDAcala:     "000000000000000000000000b91e3638F82A1fACb28690b37e3aAE45d2c33808",
+	vaa.ChainIDKlaytn:    "0000000000000000000000003c3c561757BAa0b78c5C025CdEAa4ee24C1dFfEf",
+	vaa.ChainIDCelo:      "000000000000000000000000A6A377d75ca5c9052c9a77ED1e865Cc25Bd97bf3",
 }

--- a/node/pkg/common/testnet_consts.go
+++ b/node/pkg/common/testnet_consts.go
@@ -1,0 +1,49 @@
+package common
+
+import "github.com/certusone/wormhole/node/pkg/vaa"
+
+// KnownTestnetEmitters is a list of known emitters on the various L1 testnets.
+var KnownTestnetEmitters = buildKnownEmitters(knownTestnetTokenbridgeEmitters, knownTestnetNFTBridgeEmitters)
+
+// KnownTestnetTokenbridgeEmitters is a map of known tokenbridge emitters on the various L1 testnets.
+var KnownTestnetTokenbridgeEmitters = buildEmitterMap(knownTestnetTokenbridgeEmitters)
+var knownTestnetTokenbridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:          "3b26409f8aaded3f5ddca184695aa6a0fa829b0c85caf84856324896d214ca98",
+	vaa.ChainIDEthereum:        "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+	vaa.ChainIDTerra:           "0000000000000000000000000c32d68d8f22613f6b9511872dad35a59bfdf7f0",
+	vaa.ChainIDTerra2:          "c3d4c6c2bcba163de1defb7e8f505cdb40619eee4fa618678955e8790ae1448d",
+	vaa.ChainIDBSC:             "0000000000000000000000009dcf9d205c9de35334d646bee44b2d2859712a09",
+	vaa.ChainIDPolygon:         "000000000000000000000000377D55a7928c046E18eEbb61977e714d2a76472a",
+	vaa.ChainIDAvalanche:       "00000000000000000000000061e44e506ca5659e6c0bba9b678586fa2d729756",
+	vaa.ChainIDOasis:           "00000000000000000000000088d8004a9bdbfd9d28090a02010c19897a29605c",
+	vaa.ChainIDAlgorand:        "6241ffdc032b693bfb8544858f0403dec86f2e1720af9f34f8d65fe574b6238c",
+	vaa.ChainIDAurora:          "000000000000000000000000d05ed3ad637b890d68a854d607eeaf11af456fba",
+	vaa.ChainIDFantom:          "000000000000000000000000599cea2204b4faecd584ab1f2b6aca137a0afbe8",
+	vaa.ChainIDKarura:          "000000000000000000000000d11de1f930ea1f7dd0290fe3a2e35b9c91aefb37",
+	vaa.ChainIDAcala:           "000000000000000000000000eba00cbe08992edd08ed7793e07ad6063c807004",
+	vaa.ChainIDKlaytn:          "000000000000000000000000c7a13be098720840dea132d860fdfa030884b09a",
+	vaa.ChainIDCelo:            "00000000000000000000000005ca6037ec51f8b712ed2e6fa72219feae74e153",
+	vaa.ChainIDMoonbeam:        "000000000000000000000000bc976d4b9d57e57c3ca52e1fd136c45ff7955a96",
+	vaa.ChainIDNeon:            "000000000000000000000000d11de1f930ea1f7dd0290fe3a2e35b9c91aefb37",
+	vaa.ChainIDEthereumRopsten: "000000000000000000000000F174F9A837536C449321df1Ca093Bb96948D5386",
+}
+
+// KnownTestnetNFTBridgeEmitters is a map  of known NFT emitters on the various L1 testnets.
+var KnownTestnetNFTBridgeEmitters = buildEmitterMap(knownTestnetNFTBridgeEmitters)
+var knownTestnetNFTBridgeEmitters = map[vaa.ChainID]string{
+	vaa.ChainIDSolana:          "752a49814e40b96b097207e4b53fdd330544e1e661653fbad4bc159cc28a839e",
+	vaa.ChainIDEthereum:        "000000000000000000000000d8e4c2dbdd2e2bd8f1336ea691dbff6952b1a6eb",
+	vaa.ChainIDBSC:             "000000000000000000000000cd16e5613ef35599dc82b24cb45b5a93d779f1ee",
+	vaa.ChainIDPolygon:         "00000000000000000000000051a02d0dcb5e52f5b92bdaa38fa013c91c7309a9",
+	vaa.ChainIDAvalanche:       "000000000000000000000000d601baf2eee3c028344471684f6b27e789d9075d",
+	vaa.ChainIDOasis:           "000000000000000000000000c5c25b41ab0b797571620f5204afa116a44c0eba",
+	vaa.ChainIDAurora:          "0000000000000000000000008f399607e9ba2405d87f5f3e1b78d950b44b2e24",
+	vaa.ChainIDFantom:          "00000000000000000000000063ed9318628d26bdcb15df58b53bb27231d1b227",
+	vaa.ChainIDKarura:          "0000000000000000000000000a693c2d594292b6eb89cb50efe4b0b63dd2760d",
+	vaa.ChainIDAcala:           "00000000000000000000000096f1335e0acab3cfd9899b30b2374e25a2148a6e",
+	vaa.ChainIDKlaytn:          "00000000000000000000000094c994fc51c13101062958b567e743f1a04432de",
+	vaa.ChainIDCelo:            "000000000000000000000000acd8190f647a31e56a656748bc30f69259f245db",
+	vaa.ChainIDMoonbeam:        "00000000000000000000000098a0f4b96972b32fcb3bd03caeb66a44a6ab9edb",
+	vaa.ChainIDNeon:            "000000000000000000000000a52da3b1ffd258a2ffb7719a6aee24095eee24e2",
+	vaa.ChainIDEthereumRopsten: "0000000000000000000000002b048da40f69c8dc386a56705915f8e966fe1eba",
+}


### PR DESCRIPTION
Create separate variables for the known tokenbridge and nft bridge
emitters and dynamically build KnownEmitters from those lists.  Having
separate variables for the tokenbridge and nft emitters will make it
easier to look them up without having to iterate over the whole emitter
list every time.

Also add a devnet_consts file to list the known emitters in the
development network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1317)
<!-- Reviewable:end -->
