### PR TITLE
Remove Recursive `Peel` to reduce Claim complexity.

### DIFF
--- a/solana/bridge/program/src/accounts/claim.rs
+++ b/solana/bridge/program/src/accounts/claim.rs
@@ -1,5 +1,28 @@
-//! ClaimData accounts are one off markers that can be combined with other accounts to represent
-//! data that can only be used once.
+//! Claim accounts add replay protection to Messages.
+//!
+//! Claim accounts work by having the constraint that they must be uninitialized. This means once a
+//! Claim account has been created, they can no longer be passed to an instruction. This gives us
+//! the behaviour of replay protection.
+//!
+//! Example usage:
+//!
+//! ```rust,noplayground,no_run
+//! struct ExampleAccounts {
+//!     message: PayloadMessage<'info, Example>,
+//!     claim:   Claim<'info>,
+//!     payer:   Mut<Signer<'info>>,
+//! }
+//!
+//! // Note that as a Claim must be uninitialized, only the first time this instruction is called
+//! // will succeed, subsequent calls will fail the `Uninitialized` check.
+//! fn read_message(
+//!    ctx:  &ExecutionContext,
+//!    accs: &mut ExampleAccounts,
+//!    data: (),
+//! ) {
+//!    claim::consume(ctx, &accs.payer.key, &mut accs.claim, &accs.vaa)?;
+//! }
+//! ```
 
 use borsh::{
     BorshDeserialize,
@@ -9,15 +32,63 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use solana_program::pubkey::Pubkey;
 use solitaire::{
     processors::seeded::Seeded,
     AccountOwner,
-    AccountState,
+    AccountState::*,
+    CreationLamports::Exempt,
     Data,
     Owned,
+    Result,
+    *,
 };
 
-pub type Claim<'a, const State: AccountState> = Data<'a, ClaimData, { State }>;
+use crate::{
+    DeserializePayload,
+    PayloadMessage,
+};
+
+pub type Claim<'a> = Data<'a, ClaimData, { Uninitialized }>;
+
+/// Consume a claim by initializing the account. Initialized claims act as an indicator proving
+/// that a message has been consumed.
+#[must_use]
+pub fn consume<T>(
+    ctx: &ExecutionContext,
+    payer: &Pubkey,
+    claim: &mut Claim,
+    message: &PayloadMessage<T>,
+) -> Result<()>
+where
+    T: DeserializePayload,
+{
+    // Verify that the claim account is derived correctly before claiming.
+    claim.verify_derivation(
+        ctx.program_id,
+        &ClaimDerivationData {
+            emitter_address: message.meta().emitter_address,
+            emitter_chain: message.meta().emitter_chain,
+            sequence: message.meta().sequence,
+        },
+    )?;
+
+    // Claim the account by initializing it with a value.
+    claim.create(
+        &ClaimDerivationData {
+            emitter_address: message.meta().emitter_address,
+            emitter_chain: message.meta().emitter_chain,
+            sequence: message.meta().sequence,
+        },
+        ctx,
+        payer,
+        Exempt,
+    )?;
+
+    claim.claimed = true;
+
+    Ok(())
+}
 
 #[derive(Default, Clone, Copy, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct ClaimData {
@@ -36,7 +107,7 @@ pub struct ClaimDerivationData {
     pub sequence: u64,
 }
 
-impl<'b, const State: AccountState> Seeded<&ClaimDerivationData> for Claim<'b, { State }> {
+impl<'b> Seeded<&ClaimDerivationData> for Claim<'b> {
     fn seeds(data: &ClaimDerivationData) -> Vec<Vec<u8>> {
         return vec![
             data.emitter_address.to_vec(),

--- a/solana/bridge/program/src/api/governance.rs
+++ b/solana/bridge/program/src/api/governance.rs
@@ -1,5 +1,3 @@
-use solitaire::*;
-
 use solana_program::{
     program::invoke_signed,
     pubkey::Pubkey,
@@ -11,10 +9,15 @@ use solana_program::{
 use solitaire::{
     processors::seeded::Seeded,
     CreationLamports::Exempt,
+    *,
 };
 
 use crate::{
     accounts::{
+        claim::{
+            self,
+            Claim,
+        },
         Bridge,
         GuardianSet,
         GuardianSetDerivationData,
@@ -31,19 +34,18 @@ use crate::{
         GovernancePayloadTransferFees,
         GovernancePayloadUpgrade,
     },
-    vaa::ClaimableVAA,
     DeserializePayload,
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 
+/// Fail if the emitter is not the known governance key, or the emitting chain is not Solana.
 fn verify_governance<T>(vaa: &PayloadMessage<T>) -> Result<()>
 where
     T: DeserializePayload,
 {
     let expected_emitter = std::env!("EMITTER_ADDRESS");
     let current_emitter = format!("{}", Pubkey::new_from_array(vaa.meta().emitter_address));
-    // Fail if the emitter is not the known governance key, or the emitting chain is not Solana.
     if expected_emitter != current_emitter || vaa.meta().emitter_chain != CHAIN_ID_SOLANA {
         Err(InvalidGovernanceKey.into())
     } else {
@@ -62,8 +64,8 @@ pub struct UpgradeContract<'b> {
     /// GuardianSet change VAA
     pub vaa: PayloadMessage<'b, GovernancePayloadUpgrade>,
 
-    /// Claim account representing whether the vaa has already been consumed.
-    pub vaa_claim: ClaimableVAA<'b>,
+    /// An Uninitialized Claim account to consume the VAA.
+    pub claim: Mut<Claim<'b>>,
 
     /// PDA authority for the loader
     pub upgrade_authority: Derive<Info<'b>, "upgrade">,
@@ -96,7 +98,7 @@ pub fn upgrade_contract(
     _data: UpgradeContractData,
 ) -> Result<()> {
     verify_governance(&accs.vaa)?;
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, &accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     let upgrade_ix = solana_program::bpf_loader_upgradeable::upgrade(
         ctx.program_id,
@@ -126,8 +128,8 @@ pub struct UpgradeGuardianSet<'b> {
     /// GuardianSet change VAA
     pub vaa: PayloadMessage<'b, GovernancePayloadGuardianSetChange>,
 
-    /// Claim account representing whether the vaa has already been consumed.
-    pub vaa_claim: ClaimableVAA<'b>,
+    /// An Uninitialized Claim account to consume the VAA.
+    pub claim: Mut<Claim<'b>>,
 
     /// Old guardian set
     pub guardian_set_old: Mut<GuardianSet<'b, { AccountState::Initialized }>>,
@@ -144,6 +146,9 @@ pub fn upgrade_guardian_set(
     accs: &mut UpgradeGuardianSet,
     _data: UpgradeGuardianSetData,
 ) -> Result<()> {
+    verify_governance(&accs.vaa)?;
+    claim::consume(ctx, &accs.payer.key, &mut accs.claim, &accs.vaa)?;
+
     // Enforce single increments when upgrading.
     if accs.guardian_set_old.index != accs.vaa.new_guardian_set_index - 1 {
         return Err(InvalidGuardianSetUpgrade.into());
@@ -154,7 +159,6 @@ pub fn upgrade_guardian_set(
         return Err(InvalidGuardianSetUpgrade.into());
     }
 
-    verify_governance(&accs.vaa)?;
     accs.guardian_set_old.verify_derivation(
         ctx.program_id,
         &GuardianSetDerivationData {
@@ -167,8 +171,6 @@ pub fn upgrade_guardian_set(
             index: accs.vaa.new_guardian_set_index,
         },
     )?;
-
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     // Set expiration time for the old set
     accs.guardian_set_old.expiration_time =
@@ -207,8 +209,8 @@ pub struct SetFees<'b> {
     /// Governance VAA
     pub vaa: PayloadMessage<'b, GovernancePayloadSetMessageFee>,
 
-    /// Claim account representing whether the vaa has already been consumed.
-    pub vaa_claim: ClaimableVAA<'b>,
+    /// An Uninitialized Claim account to consume the VAA.
+    pub claim: Mut<Claim<'b>>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Default)]
@@ -216,9 +218,8 @@ pub struct SetFeesData {}
 
 pub fn set_fees(ctx: &ExecutionContext, accs: &mut SetFees, _data: SetFeesData) -> Result<()> {
     verify_governance(&accs.vaa)?;
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, &accs.payer.key, &mut accs.claim, &accs.vaa)?;
     accs.bridge.config.fee = accs.vaa.fee.as_u64();
-
     Ok(())
 }
 
@@ -233,8 +234,8 @@ pub struct TransferFees<'b> {
     /// Governance VAA
     pub vaa: PayloadMessage<'b, GovernancePayloadTransferFees>,
 
-    /// Claim account representing whether the vaa has already been consumed.
-    pub vaa_claim: ClaimableVAA<'b>,
+    /// An Uninitialized Claim account to consume the VAA.
+    pub claim: Mut<Claim<'b>>,
 
     /// Account collecting tx fees
     pub fee_collector: Mut<Derive<Info<'b>, "fee_collector">>,
@@ -254,13 +255,13 @@ pub fn transfer_fees(
     accs: &mut TransferFees,
     _data: TransferFeesData,
 ) -> Result<()> {
+    verify_governance(&accs.vaa)?;
+    claim::consume(ctx, &accs.payer.key, &mut accs.claim, &accs.vaa)?;
+
     // Make sure the account loaded to receive funds is equal to the one the VAA requested.
     if accs.vaa.to != accs.recipient.key.to_bytes() {
         return Err(InvalidFeeRecipient.into());
     }
-
-    verify_governance(&accs.vaa)?;
-    accs.vaa.verify(ctx.program_id)?;
 
     let new_balance = accs
         .fee_collector
@@ -272,10 +273,6 @@ pub fn transfer_fees(
     }
 
     accs.bridge.last_lamports = new_balance;
-
-    verify_governance(&accs.vaa)?;
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
-
     // Transfer fees
     let transfer_ix = solana_program::system_instruction::transfer(
         accs.fee_collector.key,

--- a/solana/bridge/program/src/instructions.rs
+++ b/solana/bridge/program/src/instructions.rs
@@ -251,7 +251,7 @@ pub fn upgrade_contract(
     sequence: u64,
 ) -> Instruction {
     let bridge = Bridge::<'_, { AccountState::Initialized }>::key(None, &program_id);
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,
@@ -305,7 +305,7 @@ pub fn upgrade_guardian_set(
     sequence: u64,
 ) -> Instruction {
     let bridge = Bridge::<'_, { AccountState::Uninitialized }>::key(None, &program_id);
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,
@@ -354,7 +354,7 @@ pub fn set_fees(
     sequence: u64,
 ) -> Instruction {
     let bridge = Bridge::<'_, { AccountState::Uninitialized }>::key(None, &program_id);
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,
@@ -389,7 +389,7 @@ pub fn transfer_fees(
     recipient: Pubkey,
 ) -> Instruction {
     let bridge = Bridge::<'_, { AccountState::Uninitialized }>::key(None, &program_id);
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,

--- a/solana/bridge/program/src/wasm.rs
+++ b/solana/bridge/program/src/wasm.rs
@@ -379,7 +379,7 @@ pub fn claim_address(program_id: String, vaa: Vec<u8>) -> Vec<u8> {
     let program_id = Pubkey::from_str(program_id.as_str()).unwrap();
 
     let vaa = VAA::deserialize(vaa.as_slice()).unwrap();
-    let claim_key = Claim::<'_, { AccountState::Initialized }>::key(
+    let claim_key = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: vaa.emitter_address,
             emitter_chain: vaa.emitter_chain,
@@ -392,7 +392,12 @@ pub fn claim_address(program_id: String, vaa: Vec<u8>) -> Vec<u8> {
 
 #[wasm_bindgen]
 pub fn parse_posted_message(data: Vec<u8>) -> JsValue {
-    JsValue::from_serde(&PostedVAAData::try_from_slice(data.as_slice()).unwrap().message).unwrap()
+    JsValue::from_serde(
+        &PostedVAAData::try_from_slice(data.as_slice())
+            .unwrap()
+            .message,
+    )
+    .unwrap()
 }
 
 #[wasm_bindgen]

--- a/solana/modules/nft_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/nft_bridge/program/src/api/complete_transfer.rs
@@ -19,7 +19,10 @@ use crate::{
     TokenBridgeError::*,
 };
 use bridge::{
-    vaa::ClaimableVAA,
+    accounts::claim::{
+        self,
+        Claim,
+    },
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
@@ -45,7 +48,7 @@ pub struct CompleteNative<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     pub vaa: PayloadMessage<'b, PayloadTransfer>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
     pub to: Mut<Data<'b, SplAccount, { AccountState::MaybeInitialized }>>,
@@ -120,7 +123,7 @@ pub fn complete_native(
     }
 
     // Prevent vaa double signing
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     if !accs.to.is_initialized() {
         let associated_addr = spl_associated_token_account::get_associated_token_address(
@@ -162,7 +165,7 @@ pub struct CompleteWrapped<'b> {
 
     // Signed message for the transfer
     pub vaa: PayloadMessage<'b, PayloadTransfer>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
@@ -227,7 +230,7 @@ pub fn complete_wrapped(
         return Err(InvalidRecipient.into());
     }
 
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     // Initialize the NFT if it doesn't already exist
     if !accs.meta.is_initialized() {

--- a/solana/modules/nft_bridge/program/src/api/governance.rs
+++ b/solana/modules/nft_bridge/program/src/api/governance.rs
@@ -18,6 +18,7 @@ use bridge::{
         ClaimableVAA,
         DeserializePayload,
     },
+    PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 use solana_program::{
@@ -36,17 +37,14 @@ use solitaire::{
 };
 
 // Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
-fn verify_governance<T>(vaa: &ClaimableVAA<T>) -> Result<()>
+fn verify_governance<T>(vaa: &PayloadMessage<T>) -> Result<()>
 where
     T: DeserializePayload,
 {
     let expected_emitter = std::env!("EMITTER_ADDRESS");
-    let current_emitter = format!(
-        "{}",
-        Pubkey::new_from_array(vaa.message.meta().emitter_address)
-    );
+    let current_emitter = format!("{}", Pubkey::new_from_array(vaa.meta().emitter_address));
     // Fail if the emitter is not the known governance key, or the emitting chain is not Solana.
-    if expected_emitter != current_emitter || vaa.message.meta().emitter_chain != CHAIN_ID_SOLANA {
+    if expected_emitter != current_emitter || vaa.meta().emitter_chain != CHAIN_ID_SOLANA {
         Err(InvalidGovernanceKey.into())
     } else {
         Ok(())
@@ -59,7 +57,10 @@ pub struct UpgradeContract<'b> {
     pub payer: Mut<Signer<Info<'b>>>,
 
     /// GuardianSet change VAA
-    pub vaa: ClaimableVAA<'b, GovernancePayloadUpgrade>,
+    pub vaa: PayloadMessage<'b, GovernancePayloadUpgrade>,
+
+    /// Claim account representing whether the vaa has already been consumed.
+    pub vaa_claim: ClaimableVAA<'b>,
 
     /// PDA authority for the loader
     pub upgrade_authority: Derive<Info<'b>, "upgrade">,
@@ -92,13 +93,11 @@ pub fn upgrade_contract(
     _data: UpgradeContractData,
 ) -> Result<()> {
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(ctx.program_id)?;
-
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     let upgrade_ix = solana_program::bpf_loader_upgradeable::upgrade(
         ctx.program_id,
-        &accs.vaa.message.new_contract,
+        &accs.vaa.new_contract,
         accs.upgrade_authority.key,
         accs.spill.key,
     );
@@ -117,10 +116,9 @@ pub fn upgrade_contract(
 pub struct RegisterChain<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
-
     pub endpoint: Mut<Endpoint<'b, { AccountState::Uninitialized }>>,
-
-    pub vaa: ClaimableVAA<'b, PayloadGovernanceRegisterChain>,
+    pub vaa: PayloadMessage<'b, PayloadGovernanceRegisterChain>,
+    pub vaa_claim: ClaimableVAA<'b>,
 }
 
 impl<'a> From<&RegisterChain<'a>> for EndpointDerivationData {
@@ -146,8 +144,7 @@ pub fn register_chain(
 
     // Claim VAA
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     if accs.vaa.chain == CHAIN_ID_SOLANA {
         return Err(InvalidChain.into());

--- a/solana/modules/nft_bridge/program/src/instructions.rs
+++ b/solana/modules/nft_bridge/program/src/instructions.rs
@@ -298,7 +298,7 @@ fn claimable_vaa(
     message_key: Pubkey,
     vaa: PostVAAData,
 ) -> (AccountMeta, AccountMeta) {
-    let claim_key = Claim::<'_, { AccountState::Initialized }>::key(
+    let claim_key = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: vaa.emitter_address,
             emitter_chain: vaa.emitter_chain,
@@ -464,7 +464,7 @@ pub fn upgrade_contract(
     spill: Pubkey,
     sequence: u64,
 ) -> Instruction {
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use bridge::{
     vaa::ClaimableVAA,
+    PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 use solana_program::account_info::AccountInfo;
@@ -35,7 +36,8 @@ pub struct CompleteNative<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
-    pub vaa: ClaimableVAA<'b, PayloadTransfer>,
+    pub vaa: PayloadMessage<'b, PayloadTransfer>,
+    pub vaa_claim: ClaimableVAA<'b>,
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
     pub to: Mut<Data<'b, SplAccount, { AccountState::Initialized }>>,
@@ -108,13 +110,12 @@ pub fn complete_native(
     if accs.vaa.to != accs.to.info().key.to_bytes() {
         return Err(InvalidRecipient.into());
     }
-    if INVALID_VAAS.contains(&&*accs.vaa.message.info().key.to_string()) {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
         return Err(InvalidVAA.into());
     }
 
     // Prevent vaa double signing
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     let mut amount = accs.vaa.amount.as_u64();
     let mut fee = accs.vaa.fee.as_u64();
@@ -156,7 +157,8 @@ pub struct CompleteWrapped<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     // Signed message for the transfer
-    pub vaa: ClaimableVAA<'b, PayloadTransfer>,
+    pub vaa: PayloadMessage<'b, PayloadTransfer>,
+    pub vaa_claim: ClaimableVAA<'b>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
@@ -227,12 +229,11 @@ pub fn complete_wrapped(
     if accs.vaa.to != accs.to.info().key.to_bytes() {
         return Err(InvalidRecipient.into());
     }
-    if INVALID_VAAS.contains(&&*accs.vaa.message.info().key.to_string()) {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
         return Err(InvalidVAA.into());
     }
 
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -18,7 +18,10 @@ use crate::{
     INVALID_VAAS,
 };
 use bridge::{
-    vaa::ClaimableVAA,
+    accounts::claim::{
+        self,
+        Claim,
+    },
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
@@ -37,7 +40,7 @@ pub struct CompleteNative<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     pub vaa: PayloadMessage<'b, PayloadTransfer>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
     pub to: Mut<Data<'b, SplAccount, { AccountState::Initialized }>>,
@@ -115,7 +118,7 @@ pub fn complete_native(
     }
 
     // Prevent vaa double signing
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     let mut amount = accs.vaa.amount.as_u64();
     let mut fee = accs.vaa.fee.as_u64();
@@ -158,7 +161,7 @@ pub struct CompleteWrapped<'b> {
 
     // Signed message for the transfer
     pub vaa: PayloadMessage<'b, PayloadTransfer>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
@@ -233,7 +236,7 @@ pub fn complete_wrapped(
         return Err(InvalidVAA.into());
     }
 
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
@@ -17,7 +17,10 @@ use crate::{
     TokenBridgeError::*,
 };
 use bridge::{
-    vaa::ClaimableVAA,
+    accounts::claim::{
+        self,
+        Claim,
+    },
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
@@ -38,8 +41,8 @@ use solana_program::pubkey::Pubkey;
 #[repr(transparent)]
 pub struct RedeemerAccount<'b>(pub MaybeMut<Signer<Info<'b>>>);
 
-impl<'a, 'b: 'a, 'c> Peel<'a, 'b, 'c> for RedeemerAccount<'b> {
-    fn peel<I>(ctx: &'c mut Context<'a, 'b, 'c, I>) -> Result<Self>
+impl<'a, 'b: 'a> Peel<'a, 'b> for RedeemerAccount<'b> {
+    fn peel<I>(ctx: &mut Context<'a, 'b, I>) -> Result<Self>
     where
         Self: Sized,
     {
@@ -96,7 +99,7 @@ pub struct CompleteNativeWithPayload<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     pub vaa: PayloadMessage<'b, PayloadTransferWithPayload>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
     pub to: Mut<Data<'b, SplAccount, { AccountState::Initialized }>>,
@@ -181,7 +184,7 @@ pub fn complete_native_with_payload(
     }
 
     // Prevent vaa double signing
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     let mut amount = accs.vaa.amount.as_u64();
 
@@ -211,7 +214,7 @@ pub struct CompleteWrappedWithPayload<'b> {
 
     /// Signed message for the transfer
     pub vaa: PayloadMessage<'b, PayloadTransferWithPayload>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
@@ -293,7 +296,7 @@ pub fn complete_wrapped_with_payload(
         return Err(InvalidRecipient.into());
     }
 
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use bridge::{
     vaa::ClaimableVAA,
+    PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 use solana_program::account_info::AccountInfo;
@@ -94,7 +95,8 @@ pub struct CompleteNativeWithPayload<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
-    pub vaa: ClaimableVAA<'b, PayloadTransferWithPayload>,
+    pub vaa: PayloadMessage<'b, PayloadTransferWithPayload>,
+    pub vaa_claim: ClaimableVAA<'b>,
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
     pub to: Mut<Data<'b, SplAccount, { AccountState::Initialized }>>,
@@ -179,8 +181,7 @@ pub fn complete_native_with_payload(
     }
 
     // Prevent vaa double signing
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     let mut amount = accs.vaa.amount.as_u64();
 
@@ -209,7 +210,8 @@ pub struct CompleteWrappedWithPayload<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     /// Signed message for the transfer
-    pub vaa: ClaimableVAA<'b, PayloadTransferWithPayload>,
+    pub vaa: PayloadMessage<'b, PayloadTransferWithPayload>,
+    pub vaa_claim: ClaimableVAA<'b>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
 
@@ -291,8 +293,7 @@ pub fn complete_wrapped_with_payload(
         return Err(InvalidRecipient.into());
     }
 
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/create_wrapped.rs
+++ b/solana/modules/token_bridge/program/src/api/create_wrapped.rs
@@ -20,7 +20,10 @@ use crate::{
     INVALID_VAAS,
 };
 use bridge::{
-    vaa::ClaimableVAA,
+    accounts::claim::{
+        self,
+        Claim,
+    },
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
@@ -50,7 +53,7 @@ pub struct CreateWrapped<'b> {
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
     pub vaa: PayloadMessage<'b, PayloadAssetMeta>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 
     // New Wrapped
     pub mint: Mut<WrappedMint<'b, { AccountState::MaybeInitialized }>>,
@@ -117,7 +120,7 @@ pub fn create_wrapped(
         return Err(InvalidVAA.into());
     }
 
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     if accs.mint.is_initialized() {
         update_accounts(ctx, accs, data)

--- a/solana/modules/token_bridge/program/src/api/create_wrapped.rs
+++ b/solana/modules/token_bridge/program/src/api/create_wrapped.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use bridge::{
     vaa::ClaimableVAA,
+    PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 use solana_program::{
@@ -48,7 +49,8 @@ pub struct CreateWrapped<'b> {
     pub config: ConfigAccount<'b, { AccountState::Initialized }>,
 
     pub chain_registration: Endpoint<'b, { AccountState::Initialized }>,
-    pub vaa: ClaimableVAA<'b, PayloadAssetMeta>,
+    pub vaa: PayloadMessage<'b, PayloadAssetMeta>,
+    pub vaa_claim: ClaimableVAA<'b>,
 
     // New Wrapped
     pub mint: Mut<WrappedMint<'b, { AccountState::MaybeInitialized }>>,
@@ -111,12 +113,11 @@ pub fn create_wrapped(
     accs.chain_registration
         .verify_derivation(ctx.program_id, &derivation_data)?;
 
-    if INVALID_VAAS.contains(&&*accs.vaa.message.info().key.to_string()) {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
         return Err(InvalidVAA.into());
     }
 
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     if accs.mint.is_initialized() {
         update_accounts(ctx, accs, data)

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -15,10 +15,11 @@ use crate::{
     INVALID_VAAS,
 };
 use bridge::{
-    vaa::{
-        ClaimableVAA,
-        DeserializePayload,
+    accounts::claim::{
+        self,
+        Claim,
     },
+    DeserializePayload,
     PayloadMessage,
     CHAIN_ID_SOLANA,
 };
@@ -59,7 +60,7 @@ pub struct UpgradeContract<'b> {
 
     /// GuardianSet change VAA
     pub vaa: PayloadMessage<'b, GovernancePayloadUpgrade>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 
     /// PDA authority for the loader
     pub upgrade_authority: Derive<Info<'b>, "upgrade">,
@@ -96,7 +97,7 @@ pub fn upgrade_contract(
     }
 
     verify_governance(&accs.vaa)?;
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     let upgrade_ix = solana_program::bpf_loader_upgradeable::upgrade(
         ctx.program_id,
@@ -123,7 +124,7 @@ pub struct RegisterChain<'b> {
     pub endpoint: Mut<Endpoint<'b, { AccountState::Uninitialized }>>,
 
     pub vaa: PayloadMessage<'b, PayloadGovernanceRegisterChain>,
-    pub vaa_claim: ClaimableVAA<'b>,
+    pub claim: Mut<Claim<'b>>,
 }
 
 impl<'a> From<&RegisterChain<'a>> for EndpointDerivationData {
@@ -153,7 +154,7 @@ pub fn register_chain(
 
     // Claim VAA
     verify_governance(&accs.vaa)?;
-    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
     // Create endpoint
     accs.endpoint

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -19,6 +19,7 @@ use bridge::{
         ClaimableVAA,
         DeserializePayload,
     },
+    PayloadMessage,
     CHAIN_ID_SOLANA,
 };
 use solana_program::{
@@ -36,18 +37,15 @@ use solitaire::{
     *,
 };
 
-/// Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
-fn verify_governance<T>(vaa: &ClaimableVAA<T>) -> Result<()>
+// Confirm that a ClaimableVAA came from the correct chain, signed by the right emitter.
+fn verify_governance<T>(vaa: &PayloadMessage<T>) -> Result<()>
 where
     T: DeserializePayload,
 {
     let expected_emitter = std::env!("EMITTER_ADDRESS");
-    let current_emitter = format!(
-        "{}",
-        Pubkey::new_from_array(vaa.message.meta().emitter_address)
-    );
+    let current_emitter = format!("{}", Pubkey::new_from_array(vaa.meta().emitter_address));
     // Fail if the emitter is not the known governance key, or the emitting chain is not Solana.
-    if expected_emitter != current_emitter || vaa.message.meta().emitter_chain != CHAIN_ID_SOLANA {
+    if expected_emitter != current_emitter || vaa.meta().emitter_chain != CHAIN_ID_SOLANA {
         Err(InvalidGovernanceKey.into())
     } else {
         Ok(())
@@ -60,7 +58,8 @@ pub struct UpgradeContract<'b> {
     pub payer: Mut<Signer<Info<'b>>>,
 
     /// GuardianSet change VAA
-    pub vaa: ClaimableVAA<'b, GovernancePayloadUpgrade>,
+    pub vaa: PayloadMessage<'b, GovernancePayloadUpgrade>,
+    pub vaa_claim: ClaimableVAA<'b>,
 
     /// PDA authority for the loader
     pub upgrade_authority: Derive<Info<'b>, "upgrade">,
@@ -92,17 +91,16 @@ pub fn upgrade_contract(
     accs: &mut UpgradeContract,
     _data: UpgradeContractData,
 ) -> Result<()> {
-    if INVALID_VAAS.contains(&&*accs.vaa.message.info().key.to_string()) {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
         return Err(InvalidVAA.into());
     }
 
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     let upgrade_ix = solana_program::bpf_loader_upgradeable::upgrade(
         ctx.program_id,
-        &accs.vaa.message.new_contract,
+        &accs.vaa.new_contract,
         accs.upgrade_authority.key,
         accs.spill.key,
     );
@@ -124,7 +122,8 @@ pub struct RegisterChain<'b> {
 
     pub endpoint: Mut<Endpoint<'b, { AccountState::Uninitialized }>>,
 
-    pub vaa: ClaimableVAA<'b, PayloadGovernanceRegisterChain>,
+    pub vaa: PayloadMessage<'b, PayloadGovernanceRegisterChain>,
+    pub vaa_claim: ClaimableVAA<'b>,
 }
 
 impl<'a> From<&RegisterChain<'a>> for EndpointDerivationData {
@@ -148,14 +147,13 @@ pub fn register_chain(
     accs.endpoint
         .verify_derivation(ctx.program_id, &derivation_data)?;
 
-    if INVALID_VAAS.contains(&&*accs.vaa.message.info().key.to_string()) {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
         return Err(InvalidVAA.into());
     }
 
     // Claim VAA
     verify_governance(&accs.vaa)?;
-    accs.vaa.verify(ctx.program_id)?;
-    accs.vaa.claim(ctx, accs.payer.key)?;
+    accs.vaa_claim.claim(ctx, accs.payer.key, &accs.vaa)?;
 
     // Create endpoint
     accs.endpoint

--- a/solana/modules/token_bridge/program/src/api/transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/transfer_payload.rs
@@ -48,8 +48,8 @@ use super::{
 #[repr(transparent)]
 pub struct SenderAccount<'b>(pub MaybeMut<Signer<Info<'b>>>);
 
-impl<'a, 'b: 'a, 'c> Peel<'a, 'b, 'c> for SenderAccount<'b> {
-    fn peel<I>(ctx: &'c mut Context<'a, 'b, 'c, I>) -> Result<Self>
+impl<'a, 'b: 'a> Peel<'a, 'b> for SenderAccount<'b> {
+    fn peel<I>(ctx: &mut Context<'a, 'b, I>) -> Result<Self>
     where
         Self: Sized,
     {

--- a/solana/modules/token_bridge/program/src/instructions.rs
+++ b/solana/modules/token_bridge/program/src/instructions.rs
@@ -433,7 +433,7 @@ fn claimable_vaa(
     message_key: Pubkey,
     vaa: PostVAAData,
 ) -> (AccountMeta, AccountMeta) {
-    let claim_key = Claim::<'_, { AccountState::Initialized }>::key(
+    let claim_key = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: vaa.emitter_address,
             emitter_chain: vaa.emitter_chain,
@@ -872,7 +872,7 @@ pub fn upgrade_contract(
     spill: Pubkey,
     sequence: u64,
 ) -> Instruction {
-    let claim = Claim::<'_, { AccountState::Uninitialized }>::key(
+    let claim = Claim::<'_>::key(
         &ClaimDerivationData {
             emitter_address: emitter.to_bytes(),
             emitter_chain: CHAIN_ID_SOLANA,

--- a/solana/solitaire/program/src/lib.rs
+++ b/solana/solitaire/program/src/lib.rs
@@ -54,8 +54,7 @@ pub use crate::{
 };
 
 /// Library name and version to print in entrypoint. Must be evaluated in this crate in order to do the right thing
-pub const PKG_NAME_VERSION: &str =
-    concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
+pub const PKG_NAME_VERSION: &str = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
 
 pub struct ExecutionContext<'a, 'b: 'a> {
     /// A reference to the program_id of the current program.

--- a/solana/solitaire/program/src/lib.rs
+++ b/solana/solitaire/program/src/lib.rs
@@ -83,8 +83,8 @@ impl CreationLamports {
 
 /// Trait definition that describes types that can be constructed from a list of solana account
 /// references. A list of dependent accounts is produced as a side effect of the parsing stage.
-pub trait FromAccounts<'a, 'b: 'a, 'c> {
-    fn from<T>(_: &'a Pubkey, _: &'c mut Iter<'a, AccountInfo<'b>>, _: &'a T) -> Result<Self>
+pub trait FromAccounts<'a, 'b: 'a> {
+    fn from<T>(_: &'a Pubkey, _: &mut Iter<'a, AccountInfo<'b>>, _: &'a T) -> Result<Self>
     where
         Self: Sized;
 }

--- a/solana/solitaire/program/src/types/context.rs
+++ b/solana/solitaire/program/src/types/context.rs
@@ -1,54 +1,31 @@
-use crate::trace;
 use solana_program::{
-    account_info::{
-        next_account_info,
-        AccountInfo,
-    },
+    account_info::AccountInfo,
     pubkey::Pubkey,
 };
-use std::slice::Iter;
 
 /// The context is threaded through each check. Include anything within this structure that you
 /// would like to have access to as each layer of dependency is peeled off.
-pub struct Context<'a, 'b: 'a, 'c, T> {
+pub struct Context<'a, 'b: 'a, T> {
     /// A reference to the program_id of the current program.
     pub this: &'a Pubkey,
 
-    /// A reference to the instructions account list, one or more keys may be extracted during
-    /// the peeling process.
-    pub iter: &'c mut Iter<'a, AccountInfo<'b>>,
+    /// This is a reference to the AccountInfo of the field that is currently being parsed.
+    pub info: &'a AccountInfo<'b>,
 
     /// Reference to the data passed to the current instruction.
     pub data: &'a T,
-
-    /// An optional account info for this Peelable item, some fields may be other structures that
-    /// do not themselves have an account info associated with the field.
-    pub info: Option<&'a AccountInfo<'b>>,
 
     /// Whether to enforce immutability.
     pub immutable: bool,
 }
 
-impl<'a, 'b: 'a, 'c, T> Context<'a, 'b, 'c, T> {
-    pub fn new(program: &'a Pubkey, iter: &'c mut Iter<'a, AccountInfo<'b>>, data: &'a T) -> Self {
+impl<'a, 'b: 'a, T> Context<'a, 'b, T> {
+    pub fn new(this: &'a Pubkey, info: &'a AccountInfo<'b>, data: &'a T) -> Self {
         Context {
-            this: program,
-            info: None,
             immutable: true,
-            iter,
+            this,
+            info,
             data,
-        }
-    }
-
-    pub fn info<'d>(&'d mut self) -> &'a AccountInfo<'b> {
-        match self.info {
-            None => {
-                let info = next_account_info(self.iter).unwrap();
-                trace!("{}", info.key);
-                self.info = Some(info);
-                info
-            }
-            Some(v) => v,
         }
     }
 }


### PR DESCRIPTION
This PR contains two commits, both atomic changes. The change requires understanding `FromAccounts` and `Peel` so this PR is written to be as helpful as possible in explaining the change.

Commit 1 - [f44088a](https://github.com/certusone/wormhole/pull/1318/commits/f44088a7a9c39522661bf42e5573f65e8339ecd2)
================================================================================

This commit aims to remove the recursive `FromAccount` behavior. The commit is medium sized as it also includes changes to all instructions affected by the change so all programs still compile.

**Justification**

Removing this code helps with several things:

- It allows removing the `'c` lifetime sprinkled through the entire codebase which is difficult to work with.
- It would allow removing `rocksalt` in future entirely as the macros no longer need to be as complex.
- It simplifies reading the code in the future for audits and any general reader of the code.
- It makes `ClaimableVAA`'s behavior explicit and easier to reason about.

**Commit Explanation**

Solitaire parses accounts using two traits, `FromAccounts` and `Peel`. The `FromAccounts` derive macro generates a function, `FromAccounts::from()`, which repeatedly calls `Peel::peel` to construct each field in the struct:

```
let example = Example {
    foo: Peel::peel(next_account_iter(accs)?),
    bar: Peel::peel(next_account_iter(accs)?),
    baz: Peel::peel(next_account_iter(accs)?),
    ...,
}
```

The `FromAccounts` derivation also attempts to implement Peel for the structure itself however, which means `Example` itself can be embedded as a field in another accounts struct. This is currently only done with `ClaimableVAA` which is a large source of confusion.

This commit removes the recursion by:

1) Removing the `impl Peel` which the `FromAccounts` macro emits.
2) Implementing `Peel` manually on `ClaimableVAA` so it continues to work the same way.
3) In all instructions that take a `ClaimableVAA`, replace with the two underlying accounts.
4) Change verification call sites to explicitly use claim/messages.

With recursion gone, the `Context` used by Peel can be simplified as it now only ever parses a single `AccountInfo` for each field being parsed. This change is performed by:

1) Removing the `AccountInfo` iterator from Context as it is no longer needed.
2) Adds the current parsed account to `Context` instead, safe thanks to (2).

Commit 2 - [0ffc00b](https://github.com/certusone/wormhole/pull/1318/commits/0ffc00b87351651ac0c59ccbc538a0e85dc9bc54)
================================================================================

This commit simplifies `Claim` further. In Commit 1 we keep all the code identical and add a `Peel` implementation to keep the code identical to before removing the recursion. In this commit, the code for claiming is cleaned up slightly through the following steps:

1) No longer implement `ClaimVAA` as a struct, removing a layer of Peel complexity.
2) Removing `verify()` as it is never used alone without an associated `claim()`.
3) Move the account and verification logic to `accounts/claim.rs` so it's co-located with the account data.
4) In all locations use the `claim::consume` (the new verify/claim name) function instead.

This change also makes it more explicitly clear that the claim account being initialized is how we know a claim is consumed, instead of the flag/value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1318)
<!-- Reviewable:end -->
