### PR TITLE
Adds a Go implementation of auth proof concept

### DIFF
--- a/node/cmd/guardiand/authproof_test.go
+++ b/node/cmd/guardiand/authproof_test.go
@@ -1,0 +1,41 @@
+package guardiand
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAuthProof(t *testing.T) {
+	// Create some private/public keys for testing with
+	ethPrivateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	ethPublicAddress := crypto.PubkeyToAddress(ethPrivateKey.PublicKey)
+	guardianPrivateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	guardianPublicAddress := crypto.PubkeyToAddress(guardianPrivateKey.PublicKey)
+
+	// Guardian Side
+	//
+	// generates proof that ethPublic address was signed by the Guardian Private Key
+	//
+	digest := crypto.Keccak256Hash(ethPublicAddress.Bytes())
+	ethProof, err := crypto.Sign(digest.Bytes(), guardianPrivateKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, ethProof)
+
+	// Contract Side
+	//
+	// verifies proof that ethPublic address was signed by the Guardian Private Key
+	//
+	digest2 := common.BytesToHash(crypto.Keccak256(ethPublicAddress.Bytes()))
+	guardianPublicAddressBytes, _ := crypto.Ecrecover(digest2.Bytes(), ethProof)
+	guardianPublicAddress2 := common.BytesToAddress(crypto.Keccak256(guardianPublicAddressBytes[1:])[12:])
+
+	// Assert the digests are the same
+	assert.Equal(t, digest, digest2)
+
+	// Assert that the guardianPublicAddress from the proof is valid
+	assert.Equal(t, guardianPublicAddress, guardianPublicAddress2)
+}


### PR DESCRIPTION
penjaga paket

impor (
	"crypto/ecdsa"
	"kripto/rand"
	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/crypto"
	"github.com/stretchr/testify/assert"
	"pengujian"
)

func  TestAuthProof ( t  * pengujian. T ) {
	// Buat beberapa kunci privat/publik untuk pengujian dengan
	ethPrivateKey , _  :=  ecdsa . GenerateKey ( crypto . S256 ( ), rand . Reader )
	ethPublicAddress  :=  kripto . PubkeyToAddress ( ethPrivateKey . PublicKey )
	guardianPrivateKey , _  :=  ecdsa . GenerateKey ( crypto . S256 ( ), rand . Reader )
	guardianPublicAddress  :=  kripto . PubkeyToAddress ( guardianPrivateKey . PublicKey )

	// Sisi Penjaga
	//
	// menghasilkan bukti bahwa alamat ethPublic ditandatangani oleh Kunci Pribadi Penjaga
	//
	intisari  :=  kripto . Keccak256Hash ( ethPublicAddress . Bytes ())
	ethProof , err  :=  kripto . Masuk ( intisari . Bytes ( ), guardianPrivateKey )
	menegaskan . Nihil ( t , err )
	menegaskan . Tidak Nihil ( t , ethProof )

	// Sisi Kontrak
	//
	// memverifikasi bukti bahwa alamat ethPublic ditandatangani oleh Kunci Pribadi Penjaga
	//
	intisari2  :=  umum . BytesToHash ( crypto . Keccak256 ( ethPublicAddress . Bytes ()))
	guardianPublicAddressBytes , _  :=  kripto . Ecrecover ( digest2 . Bytes (), ethProof )
	guardianPublicAddress2  :=  umum . BytesToAddress ( crypto . Keccak256 ( guardianPublicAddressBytes [ 1 :])[ 12 :])

	// Nyatakan intisarinya sama
	menegaskan . Sama ( t , cerna , cerna2 )

	// Nyatakan bahwa guardianPublicAddress dari bukti adalah valid
	menegaskan .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1330)
<!-- Reviewable:end -->
