### PR TITLE
Optimise guardian set init script

### DIFF
--- a/Dockerfile.const
+++ b/Dockerfile.const
@@ -10,6 +10,7 @@ RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/pki/tls/certs/ca-bun
 
 # fetch scripts/guardian-set-init.sh deps
 RUN dnf -y install jq
+RUN dnf -y install make
 
 # fetch clients/** deps
 RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && dnf -y install nodejs
@@ -19,7 +20,7 @@ ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
 ENV NODE_OPTIONS=--use-openssl-ca
 RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
 
-# install token_bridge deps & build
+# install CLI deps & build
 WORKDIR /clients/js
 # copy package.json & package-lock.json by themselves to create a cache layer
 COPY clients/js/package.json clients/js/package-lock.json ./
@@ -27,6 +28,8 @@ COPY clients/js/package.json clients/js/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci
 # copy the rest of the source files, as a layer on top of the deps
 COPY clients/js ./
+# build CLI
+RUN make build
 
 WORKDIR /
 

--- a/scripts/guardian-set-init.sh
+++ b/scripts/guardian-set-init.sh
@@ -25,7 +25,13 @@ function upsert_env_file {
     # replace the value if it exists, else, append it to the file
     if [[ -f $file ]] && grep -q "^$key=" $file; then
         # file has the key, update it:
-        sed -i "/^$key=/s/=.*/=$new_value/" $file
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # on macOS's sed, the -i flag needs the '' argument to not create
+            # backup files
+            sed -i '' -e "/^$key=/s/=.*/=$new_value/" $file
+        else
+            sed -i -e "/^$key=/s/=.*/=$new_value/" $file
+        fi
     else
         # file does not have the key, add it:
         echo "$key=$new_value" >> $file

--- a/scripts/guardian-set-init.sh
+++ b/scripts/guardian-set-init.sh
@@ -15,7 +15,6 @@ ethFile="./scripts/.env.0x" # for "0x" prefixed data, for ethereum scripts
 # copy the eth defaults so we can override just the things we need
 cp ./ethereum/.env.test $ethFile
 
-
 # function for updating or inserting a KEY=value pair in a file.
 function upsert_env_file {
     file=${1} # file will be created if it does not exist.
@@ -43,6 +42,10 @@ if ! type -p jq; then
     echo "ERROR: jq is not installed"! >&2
     exit 1
 fi
+
+# Rebuild the CLI binary if needed. If the binary is already up to date, this
+# command finishes in a fraction of a second.
+make build -C ./clients/js
 
 
 # 1) guardian public keys - used as the inital guardian set when initializing contracts.
@@ -88,28 +91,21 @@ solNFTBridge=$(jq --raw-output '.chains."1".contracts.nftBridgeEmitterAddress' $
 ethNFTBridge=$(jq --raw-output '.chains."2".contracts.nftBridgeEmitterAddress' $addressesJson)
 terraNFTBridge=$(jq --raw-output '.chains."3".contracts.nftBridgeEmitterAddress' $addressesJson)
 
-
 # 4) create token bridge registration VAAs
-echo "generating contract registration VAAs for token bridges"
-# fetch dependencies for the clients/token_bridge script that generates token bridge registration VAAs
-if [[ ! -d ./clients/js/node_modules ]]; then
-    echo "going to install node modules in clients/js"
-    npm ci --prefix clients/js
-fi
-# invoke clients/token_bridge commands to create registration VAAs
-solTokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c solana -a ${solTokenBridge} -g ${guardiansPrivateCSV})
-ethTokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c ethereum -a ${ethTokenBridge} -g ${guardiansPrivateCSV} )
-terraTokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c terra -a ${terraTokenBridge} -g ${guardiansPrivateCSV})
-bscTokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c bsc -a ${bscTokenBridge} -g ${guardiansPrivateCSV})
-algoTokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c algorand -a ${algoTokenBridge} -g ${guardiansPrivateCSV})
-terra2TokenBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m TokenBridge -c terra2 -a ${terra2TokenBridge} -g ${guardiansPrivateCSV})
+# invoke CLI commands to create registration VAAs
+solTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c solana -a ${solTokenBridge} -g ${guardiansPrivateCSV})
+ethTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c ethereum -a ${ethTokenBridge} -g ${guardiansPrivateCSV} )
+terraTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c terra -a ${terraTokenBridge} -g ${guardiansPrivateCSV})
+bscTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c bsc -a ${bscTokenBridge} -g ${guardiansPrivateCSV})
+algoTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c algorand -a ${algoTokenBridge} -g ${guardiansPrivateCSV})
+terra2TokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c terra2 -a ${terra2TokenBridge} -g ${guardiansPrivateCSV})
 
 
 # 5) create nft bridge registration VAAs
 echo "generating contract registration VAAs for nft bridges"
-solNFTBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m NFTBridge -c solana -a ${solNFTBridge} -g ${guardiansPrivateCSV})
-ethNFTBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m NFTBridge -c ethereum -a ${ethNFTBridge} -g ${guardiansPrivateCSV})
-terraNFTBridgeVAA=$(npm --prefix clients/js start --silent -- generate registration -m NFTBridge -c terra -a ${terraNFTBridge} -g ${guardiansPrivateCSV})
+solNFTBridgeVAA=$(node ./clients/js/build/main.js generate registration -m NFTBridge -c solana -a ${solNFTBridge} -g ${guardiansPrivateCSV})
+ethNFTBridgeVAA=$(node ./clients/js/build/main.js generate registration -m NFTBridge -c ethereum -a ${ethNFTBridge} -g ${guardiansPrivateCSV})
+terraNFTBridgeVAA=$(node ./clients/js/build/main.js generate registration -m NFTBridge -c terra -a ${terraNFTBridge} -g ${guardiansPrivateCSV})
 
 
 


### PR DESCRIPTION
Use prebuilt CLI executable instead of invoking with 'ts-node'. This way the script runs 10 times
faster, 40s->4s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1331)
<!-- Reviewable:end -->
