### PR TITLE
Docker FROM image pinning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,3 +151,10 @@ jobs:
         with:
           command: test
           args: --workspace --manifest-path ${{ matrix.manifest }}
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+      - run: chmod 755 ./scripts/check-docker-pin.sh
+      - run: ./scripts/check-docker-pin.sh

--- a/Dockerfile.const
+++ b/Dockerfile.const
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/fedora:34 AS const-build
+FROM docker.io/fedora:34@sha256:321dbc444dfeda328a85dc3c31545a65c1fae8390aa5ba6dc1f5222b53b42697 AS const-build
 
 ARG num_guardians
 ENV NUM_GUARDIANS=$num_guardians

--- a/algorand/Dockerfile
+++ b/algorand/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/python:3.10
+FROM docker.io/python:3.10@sha256:eeed7cac682f9274d183f8a7533ee1360a26acb3616aa712b2be7896f80d8c5f
 
 # Support additional root CAs
 COPY README.md cert.pem* /certs/

--- a/algorand/sandbox-algorand/images/Dockerfile
+++ b/algorand/sandbox-algorand/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:fd92c36d3cb9b1d027c4d2a72c6bf0125da82425fc2ca37c414d4f010180dc19
 ARG channel
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/algorand/sandbox-algorand/images/algod/Dockerfile
+++ b/algorand/sandbox-algorand/images/algod/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.18.2
-FROM golang:$GO_VERSION as algorand-algod
+FROM golang:$GO_VERSION@sha256:04fab5aaf4fc18c40379924674491d988af3d9e97487472e674d0b5fd837dfac as algorand-algod
 
 # Support additional root CAs
 COPY config.dev cert.pem* /certs/

--- a/algorand/sandbox-algorand/images/indexer/Dockerfile
+++ b/algorand/sandbox-algorand/images/indexer/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.18.2
-FROM golang:$GO_VERSION-alpine
+FROM golang:$GO_VERSION-alpine@sha256:4795c5d21f01e0777707ada02408debe77fe31848be97cf9fa8a1462da78d949
 
 # Support additional root CAs
 COPY config.dev cert.pem* /certs/

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -4,7 +4,7 @@
 #   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
 #   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
 #
-find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | grep -v sha256
+find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | grep -v sha256 | grep -v "solana AS builder" | grep -v "solana AS ci_tests" | grep -v "node_modules"
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files"
    exit 1

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -4,7 +4,7 @@
 #   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
 #   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
 #
-find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | egrep -v 'scratch|sha256|solana AS builder|solana AS ci_tests|node_module'
+find . -name 'Dockerfile*' -print0  -type f | xargs -0 grep -s "FROM" {} | grep -v scratch | egrep -v 'scratch|sha256|solana AS builder|solana AS ci_tests|node_module'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -4,9 +4,9 @@
 #   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
 #   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
 #
-find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | grep -v sha256 | grep -v "solana AS builder" | grep -v "solana AS ci_tests" | grep -v "node_modules"
+find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | egrep -v 'scratch|sha256|solana AS builder|solana AS ci_tests|node_module'
 if [ $? -eq 0 ]; then
-   echo "[!] Unpinned docker files"
+   echo "[!] Unpinned docker files" >&2
    exit 1
 else
    echo "[+] No unpinned docker files"

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -1,0 +1,14 @@
+# This script is checks to that all our Docker images are pinned to a specific SHA256 hash
+#
+# References as to why...
+#   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
+#   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
+#
+find ~+ -type f -name "Docker*" -print0 | xargs -0 grep -s "FROM" {} | grep -v scratch | grep -v sha256
+if [ $? -eq 0 ]; then
+   echo "[!] Unpinned docker files"
+   exit 1
+else
+   echo "[+] No unpinned docker files"
+   exit 0
+fi

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -6,7 +6,12 @@
 #   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
 #   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
 #
-find . -name 'Dockerfile*' -print0  -type f | xargs -0 grep -s "FROM" {} | egrep -v 'scratch|sha256|solana AS (builder|ci_tests)|node_module'
+# Explaination of regex ignore choices
+#   - We ignore sha256 because it suggests that the image dep is pinned
+#   - We ignore scratch because it's literally the docker base image
+#   - We ignore solana AS (builder|ci_tests) because it's a relative reference to another FROM call
+#
+git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana AS (builder|ci_tests)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is checks to that all our Docker images are pinned to a specific SHA256 hash
 #

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -1,14 +1,15 @@
+#!/bin/bash
+
 # This script is checks to that all our Docker images are pinned to a specific SHA256 hash
 #
 # References as to why...
 #   - https://nickjanetakis.com/blog/docker-tip-18-please-pin-your-docker-image-versions
 #   - https://snyk.io/blog/10-docker-image-security-best-practices/ (Specifically: USE FIXED TAGS FOR IMMUTABILITY)
 #
-find . -name 'Dockerfile*' -print0  -type f | xargs -0 grep -s "FROM" {} | grep -v scratch | egrep -v 'scratch|sha256|solana AS builder|solana AS ci_tests|node_module'
+find . -name 'Dockerfile*' -print0  -type f | xargs -0 grep -s "FROM" {} | egrep -v 'scratch|sha256|solana AS (builder|ci_tests)|node_module'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1
 else
    echo "[+] No unpinned docker files"
-   exit 0
 fi

--- a/third_party/redis/Dockerfile
+++ b/third_party/redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14@sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis


### PR DESCRIPTION
This PR introduces the following:

- Pins all our unpinned Docker image dependancies
- Adds a script to check the repo for unpinned dependancies
- Adds a job in the CI build workflow that runs the script, which will fail the build if we have an unpinned Docker image dep

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1337)
<!-- Reviewable:end -->
