### PR TITLE
Move from ADD to COPY on Dockerfiles

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -20,8 +20,8 @@ RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
     npm ci
 COPY clients/js ./
 
-ADD solana /usr/src/solana
-ADD proto /usr/src/proto
+COPY solana /usr/src/solana
+COPY proto /usr/src/proto
 
 WORKDIR /usr/src/solana
 

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -8,8 +8,8 @@ RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certifi
 
 RUN mkdir /app
 
-ADD tools/build.sh /app/tools/
-ADD tools/go.* /app/tools/
+COPY tools/build.sh /app/tools/
+COPY tools/go.* /app/tools/
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
 	cd /app/tools && CGO_ENABLED=0 ./build.sh
@@ -24,8 +24,8 @@ RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certifi
 
 COPY --from=go-tools /app /app
 
-ADD buf.* /app
-ADD proto /app/proto
+COPY buf.* /app
+COPY proto /app/proto
 
 RUN --mount=type=cache,target=/root/.cache \
 	cd /app && \
@@ -41,11 +41,11 @@ RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
 
 COPY --from=go-tools /app /app
 
-ADD buf.* /app
-ADD proto /app/proto
+COPY buf.* /app
+COPY proto /app/proto
 
-ADD tools/package.json /app/tools/
-ADD tools/package-lock.json /app/tools/
+COPY tools/package.json /app/tools/
+COPY tools/package-lock.json /app/tools/
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/root/.npm \
  	cd /app/tools && npm ci

--- a/cosmwasm/devnet/Dockerfile
+++ b/cosmwasm/devnet/Dockerfile
@@ -1,3 +1,3 @@
 FROM terramoney/localterra-core:2.0.1@sha256:73faa857d32b869b6bd3bf062351bd47ca5440d758dc07d5481424b9a9bdaede
 
-ADD config /root/.terra/config
+COPY config /root/.terra/config

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -24,9 +24,9 @@ RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
 RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
 
 # Only invalidate the npm install step if package.json changed
-ADD --chown=node:node package.json .
-ADD --chown=node:node package-lock.json .
-ADD --chown=node:node .env.test .env
+COPY --chown=node:node package.json .
+COPY --chown=node:node package-lock.json .
+COPY --chown=node:node .env.test .env
 
 # We want to cache node_modules *and* incorporate it into the final image.
 RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
@@ -39,4 +39,4 @@ RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
 # could be a renameat syscall. Alpine does not have this bug.
 RUN rm -rf node_modules && mv node_modules_cache node_modules
 
-ADD --chown=node:node . .
+COPY --chown=node:node . .

--- a/event_database/functions_server/Dockerfile
+++ b/event_database/functions_server/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/golang:1.17.0@sha256:06e92e576fc7a7067a268d47727f3083c0a564331bfc
 
 WORKDIR /app
 
-ADD . .
+COPY . .
 
 WORKDIR /app/functions_server
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,12 +10,12 @@ RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/ce
 
 WORKDIR /app
 
-ADD tools tools
+COPY tools tools
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
   cd tools/ && go build -mod=readonly -o /dlv github.com/go-delve/delve/cmd/dlv
 
-ADD . .
+COPY . .
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
   go build -race -gcflags="all=-N -l" --ldflags '-extldflags "-Wl,--allow-multiple-definition"' -mod=readonly -o /guardiand github.com/certusone/wormhole/node && \

--- a/relayer/spy_relayer/Dockerfile
+++ b/relayer/spy_relayer/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add python3 \
         make \
         g++ 
 
-ADD . .
+COPY . .
 
 RUN echo $(ls -1 .)
 RUN echo $(less Dockerfile)

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -36,7 +36,7 @@ RUN touch /tmp/foo.so && \
 # Add bridge contract sources
 WORKDIR /usr/src/bridge
 
-ADD . .
+COPY . .
 
 ENV RUST_LOG="solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=trace,solana_bpf_loader=debug,solana_rbpf=debug"
 ENV RUST_BACKTRACE=1

--- a/terra/devnet/Dockerfile
+++ b/terra/devnet/Dockerfile
@@ -1,3 +1,3 @@
 FROM terramoney/localterra-core:bombay@sha256:0f93576ae0716f835b2adbd5ac550ef90063b536e99c4dd682b6dd905927f261
 
-ADD config /root/.terra/config
+COPY config /root/.terra/config

--- a/third_party/abigen-celo/Dockerfile
+++ b/third_party/abigen-celo/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt install curl git gcc libc-dev
 
 WORKDIR /app
 
-ADD go.mod .
-ADD go.sum .
+COPY go.mod .
+COPY go.sum .
 
 RUN go build -o /bin/abigen github.com/celo-org/celo-blockchain/cmd/abigen

--- a/third_party/abigen/Dockerfile
+++ b/third_party/abigen/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add curl git gcc libc-dev linux-headers
 
 WORKDIR /app
 
-ADD go.mod .
-ADD go.sum .
+COPY go.mod .
+COPY go.sum .
 
 RUN go build -mod=readonly -o /bin/abigen github.com/ethereum/go-ethereum/cmd/abigen

--- a/third_party/redis/Dockerfile
+++ b/third_party/redis/Dockerfile
@@ -95,7 +95,7 @@ RUN mkdir /data && chown redis:redis /data
 VOLUME /data
 WORKDIR /data
 
-ADD . .
+COPY . .
 RUN chmod 777 /data/third_party/redis/docker-entrypoint.sh
 RUN cp /data/third_party/redis/docker-entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
Reference: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

COPY is generally preferred unless we need to make use of the more powerful features within ADD, which it appears we are not using.  The most common example case is that ADD can pull in remote files and auto-magically explode tarballs, neither of which we are doing here, so it's nice to just sidestep those two use cases, which could be abused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1338)
<!-- Reviewable:end -->
