### PR TITLE
CI: pin foundry version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: "16"
       - run: cd clients/js && make install
       - run: curl -L https://foundry.paradigm.xyz | bash
-      - run: $HOME/.foundry/bin/foundryup
+      - run: $HOME/.foundry/bin/foundryup -v nightly-4367ce1c3d2c10b71350b40258766d53a94c717f
       - run: cd ethereum && PATH=$PATH:$HOME/.foundry/bin/ make test-upgrade
 
   terra:


### PR DESCRIPTION
The latest nightly broke the ugprade test, not yet sure how. For now,
just pin the older version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1344)
<!-- Reviewable:end -->
