### PR TITLE
Update injective url/s

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -958,7 +958,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *terraWS != "" {
 			logger.Info("Starting Terra watcher")
 			if err := supervisor.Run(ctx, "terrawatch",
-				cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, lockC, setC, chainObsvReqC[vaa.ChainIDTerra], common.ReadinessTerraSyncing, vaa.ChainIDTerra).Run); err != nil {
+				cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, lockC, chainObsvReqC[vaa.ChainIDTerra], common.ReadinessTerraSyncing, vaa.ChainIDTerra).Run); err != nil {
 				return err
 			}
 		}
@@ -966,7 +966,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *terra2WS != "" {
 			logger.Info("Starting Terra 2 watcher")
 			if err := supervisor.Run(ctx, "terra2watch",
-				cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, lockC, setC, chainObsvReqC[vaa.ChainIDTerra2], common.ReadinessTerra2Syncing, vaa.ChainIDTerra2).Run); err != nil {
+				cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, lockC, chainObsvReqC[vaa.ChainIDTerra2], common.ReadinessTerra2Syncing, vaa.ChainIDTerra2).Run); err != nil {
 				return err
 			}
 		}
@@ -974,7 +974,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *testnetMode {
 			logger.Info("Starting Injective watcher")
 			if err := supervisor.Run(ctx, "injectivewatch",
-				cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, lockC, setC, chainObsvReqC[vaa.ChainIDInjective], common.ReadinessInjectiveSyncing, vaa.ChainIDInjective).Run); err != nil {
+				cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, lockC, chainObsvReqC[vaa.ChainIDInjective], common.ReadinessInjectiveSyncing, vaa.ChainIDInjective).Run); err != nil {
 				return err
 			}
 		}

--- a/node/pkg/terra/watcher.go
+++ b/node/pkg/terra/watcher.go
@@ -183,7 +183,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 		for {
 			<-t.C
-
+			msm := time.Now()
 			// Query and report height and set currentSlotHeight
 			resp, err := client.Get(fmt.Sprintf("%s/%s", e.urlLCD, e.latestBlockURL))
 			if err != nil {
@@ -198,6 +198,9 @@ func (e *Watcher) Run(ctx context.Context) error {
 				continue
 			}
 			resp.Body.Close()
+
+			// Update the prom metrics with how long the http request took to the rpc
+			queryLatency.WithLabelValues(networkName, "block_latest").Observe(time.Since(msm).Seconds())
 
 			blockJSON := string(blocksBody)
 			latestBlock := gjson.Get(blockJSON, "block.header.height")

--- a/node/pkg/terra/watcher.go
+++ b/node/pkg/terra/watcher.go
@@ -92,7 +92,6 @@ func NewWatcher(
 	urlLCD string,
 	contract string,
 	lockEvents chan *common.MessagePublication,
-	setEvents chan *common.GuardianSet,
 	obsvReqC chan *gossipv1.ObservationRequest,
 	readiness readiness.Component,
 	chainID vaa.ChainID) *Watcher {
@@ -106,7 +105,7 @@ func NewWatcher(
 		contractAddressLogKey = "contract_address"
 	}
 
-	return &Watcher{urlWS: urlWS, urlLCD: urlLCD, contract: contract, msgChan: lockEvents, setChan: setEvents, obsvReqC: obsvReqC, readiness: readiness, chainID: chainID, contractAddressFilterKey: contractAddressFilterKey, contractAddressLogKey: contractAddressLogKey}
+	return &Watcher{urlWS: urlWS, urlLCD: urlLCD, contract: contract, msgChan: lockEvents, obsvReqC: obsvReqC, readiness: readiness, chainID: chainID, contractAddressFilterKey: contractAddressFilterKey, contractAddressLogKey: contractAddressLogKey}
 }
 
 func (e *Watcher) Run(ctx context.Context) error {


### PR DESCRIPTION
This change ensures that the injective watcher uses the correct url for getting the blockheight.

It also removes the guardian set info bits from the terra^Wcosmwasm watcher since those only make sense on Ethereum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1350)
<!-- Reviewable:end -->
