### PR TITLE
cloud_functions: use daily token prices to compute cumulative TVL

### DIFF
--- a/event_database/cloud_functions/notional-transferred-to.go
+++ b/event_database/cloud_functions/notional-transferred-to.go
@@ -31,17 +31,18 @@ var muWarmTransfersToCache sync.RWMutex
 var warmTransfersToCacheFilePath = "notional-transferred-to-cache.json"
 
 type TransferData struct {
-	TokenSymbol      string
-	TokenName        string
-	TokenAddress     string
-	TokenAmount      float64
-	CoinGeckoCoinId  string
-	OriginChain      string
-	LeavingChain     string
-	DestinationChain string
-	Notional         float64
-	TokenPrice       float64
-	TokenDecimals    int
+	TokenSymbol       string
+	TokenName         string
+	TokenAddress      string
+	TokenAmount       float64
+	CoinGeckoCoinId   string
+	OriginChain       string
+	LeavingChain      string
+	DestinationChain  string
+	Notional          float64
+	TokenPrice        float64
+	TokenDecimals     int
+	TransferTimestamp string
 }
 
 // finds all the TokenTransfer rows within the specified period
@@ -83,6 +84,8 @@ func fetchTransferRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefi
 					t.CoinGeckoCoinId = string(item.Value)
 				case "TokenTransferDetails:Decimals":
 					t.TokenDecimals, _ = strconv.Atoi(string(item.Value))
+				case "TokenTransferDetails:TransferTimestamp":
+					t.TransferTimestamp = string(item.Value)
 				}
 			}
 
@@ -100,7 +103,8 @@ func fetchTransferRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefi
 			keyParts := strings.Split(row.Key(), ":")
 			t.LeavingChain = keyParts[0]
 
-			if isTokenAllowed(t.OriginChain, t.TokenAddress) {
+			transferDateStr := t.TransferTimestamp[0:10]
+			if isTokenAllowed(t.OriginChain, t.TokenAddress) && isTokenActive(t.OriginChain, t.TokenAddress, transferDateStr) {
 				rows = append(rows, *t)
 			}
 		}
@@ -116,8 +120,8 @@ func fetchTransferRowsInInterval(tbl *bigtable.Table, ctx context.Context, prefi
 				bigtable.StripValueFilter(),               // no columns/values, just the row.Key()
 			),
 			bigtable.ChainFilters(
-				bigtable.FamilyFilter(fmt.Sprintf("%v|%v", columnFamilies[2], columnFamilies[5])),
-				bigtable.ColumnFilter("Amount|NotionalUSD|OriginSymbol|OriginName|OriginChain|TargetChain|CoinGeckoCoinId|OriginTokenAddress|TokenPriceUSD|Decimals"),
+				bigtable.FamilyFilter(fmt.Sprintf("%v|%v", transferPayloadFam, transferDetailsFam)),
+				bigtable.ColumnFilter("Amount|NotionalUSD|OriginSymbol|OriginName|OriginChain|TargetChain|CoinGeckoCoinId|OriginTokenAddress|TokenPriceUSD|Decimals|TransferTimestamp"),
 				bigtable.LatestNFilter(1),
 			),
 			bigtable.BlockAllFilter(),

--- a/event_database/cloud_functions/notional-tvl-cumulative.go
+++ b/event_database/cloud_functions/notional-tvl-cumulative.go
@@ -27,10 +27,56 @@ var warmTvlCumulativeCacheFilePath = "tvl-cumulative-cache.json"
 
 var notionalTvlCumulativeResultPath = "notional-tvl-cumulative.json"
 
+var coinGeckoPriceCacheFilePath = "coingecko-price-cache.json"
+var coinGeckoPriceCache = map[string]map[string]float64{}
+var loadedCoinGeckoPriceCache bool
+
 // days to be excluded from the TVL result
 var skipDays = map[string]bool{
 	// for example:
 	// "2022-02-19": true,
+}
+
+func loadAndUpdateCoinGeckoPriceCache(ctx context.Context, coinIds []string, now time.Time) {
+	// at cold-start, load the price cache into memory, and fetch any missing token price histories and add them to the cache
+	if !loadedCoinGeckoPriceCache {
+		// load the price cache
+		loadJsonToInterface(ctx, coinGeckoPriceCacheFilePath, &muWarmTvlCumulativeCache, &coinGeckoPriceCache)
+		loadedCoinGeckoPriceCache = true
+
+		// find tokens missing price history
+		missing := []string{}
+		for _, coinId := range coinIds {
+			found := false
+			for _, prices := range coinGeckoPriceCache {
+				if _, ok := prices[coinId]; ok {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missing = append(missing, coinId)
+			}
+		}
+
+		// fetch missing price histories and add them to the cache
+		priceHistories := fetchTokenPriceHistories(ctx, missing, releaseDay, now)
+		for date, prices := range priceHistories {
+			for coinId, price := range prices {
+				if _, ok := coinGeckoPriceCache[date]; !ok {
+					coinGeckoPriceCache[date] = map[string]float64{}
+				}
+				coinGeckoPriceCache[date][coinId] = price
+			}
+		}
+	}
+
+	// fetch today's latest prices
+	today := now.Format("2006-01-02")
+	coinGeckoPriceCache[today] = fetchTokenPrices(ctx, coinIds)
+
+	// write to the cache file
+	persistInterfaceToJson(ctx, coinGeckoPriceCacheFilePath, &muWarmCumulativeAddressesCache, coinGeckoPriceCache)
 }
 
 // calculates a running total of notional value transferred, by symbol, since the start time specified.
@@ -238,6 +284,22 @@ func ComputeTvlCumulative(w http.ResponseWriter, r *http.Request) {
 
 	transfers := createTvlCumulativeOfInterval(tbl, ctx, start)
 
+	coinIdSet := map[string]bool{}
+	for _, chains := range transfers {
+		for _, assets := range chains {
+			for _, asset := range assets {
+				if asset.CoinGeckoId != "*" {
+					coinIdSet[asset.CoinGeckoId] = true
+				}
+			}
+		}
+	}
+	coinIds := []string{}
+	for coinId := range coinIdSet {
+		coinIds = append(coinIds, coinId)
+	}
+	loadAndUpdateCoinGeckoPriceCache(ctx, coinIds, now)
+
 	// calculate the notional tvl based on the price of the tokens each day
 	for date, chains := range transfers {
 		if _, ok := skipDays[date]; ok {
@@ -265,7 +327,16 @@ func ComputeTvlCumulative(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 
-				notional := asset.Amount * asset.TokenPrice
+				// asset.TokenPrice is the price that was fetched when this token was last transferred, possibly before this date
+				// prefer to use the cached price for this date if it's available, because it might be newer
+				tokenPrice := asset.TokenPrice
+				if prices, ok := coinGeckoPriceCache[date]; ok {
+					if price, ok := prices[asset.CoinGeckoId]; ok {
+						// use the cached price
+						tokenPrice = price
+					}
+				}
+				notional := asset.Amount * tokenPrice
 				if notional <= 0 {
 					continue
 				}


### PR DESCRIPTION
Use daily token prices to compute TVL instead of the prices fetched
at token transfer time, if available.

Added inactive tokenlist to exclude tokens that have essentially been
deactivated by CoinGecko (market data no longer available).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1366)
<!-- Reviewable:end -->
