### PR TITLE
cosmwasm: move chain id and fee denom to storage

### DIFF
--- a/cosmwasm/contracts/token-bridge/_tests/integration.rs
+++ b/cosmwasm/contracts/token-bridge/_tests/integration.rs
@@ -75,6 +75,8 @@ fn do_init(
         },
         guardian_set_expirity: 50,
         wrapped_asset_code_id: 999,
+        chain_id: 18,
+        fee_denom: "uluna".to_string(),
     };
     let env = mock_env_height(&TestAddress::INITIALIZER.value(), height, 0);
     let owner = deps
@@ -95,6 +97,7 @@ fn do_init(
                 wrapped_asset_code_id: 999,
                 owner,
                 fee: Coin::new(10000, "uluna"),
+                chain_id: 18,
             }
         );
         Ok(())

--- a/cosmwasm/contracts/token-bridge/src/lib.rs
+++ b/cosmwasm/contracts/token-bridge/src/lib.rs
@@ -8,6 +8,3 @@ pub mod token_address;
 
 #[cfg(test)]
 mod testing;
-
-// Chain ID of Terra 2.0
-pub const CHAIN_ID: u16 = 18;

--- a/cosmwasm/contracts/token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/token-bridge/src/msg.rs
@@ -19,14 +19,17 @@ use crate::token_address::{
 
 type HumanAddr = String;
 
+/// The instantiation parameters of the token bridge contract. See
+/// [`crate::state::ConfigInfo`] for more details on what these fields mean.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    // governance contract details
     pub gov_chain: u16,
     pub gov_address: Binary,
 
     pub wormhole_contract: HumanAddr,
     pub wrapped_asset_code_id: u64,
+
+    pub chain_id: u16,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/cosmwasm/contracts/token-bridge/src/testing/tests.rs
+++ b/cosmwasm/contracts/token-bridge/src/testing/tests.rs
@@ -61,14 +61,13 @@ fn build_native_and_asset_ids() -> StdResult<()> {
     );
 
     // weth
-    let chain = 2u16;
     let token_address = "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
     let token_address: [u8; 32] = hex::decode(token_address)
         .unwrap()
         .as_slice()
         .try_into()
         .unwrap();
-    let external_id_weth = ExternalTokenId::from_foreign_token(chain, token_address);
+    let external_id_weth = ExternalTokenId::from_foreign_token(token_address);
 
     let expected_asset_id: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 192, 42, 170, 57, 178, 35, 254, 141, 10, 14, 92, 79, 39, 234, 217, 8, 60, 117, 108, 194];
     assert_eq!(

--- a/cosmwasm/contracts/wormhole/src/msg.rs
+++ b/cosmwasm/contracts/wormhole/src/msg.rs
@@ -15,13 +15,19 @@ use crate::state::{
 
 type HumanAddr = String;
 
+/// The instantiation parameters of the token bridge contract. See
+/// [`crate::state::ConfigInfo`] for more details on what these fields mean.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub gov_chain: u16,
     pub gov_address: Binary,
 
+    /// Guardian set to initialise the contract with.
     pub initial_guardian_set: GuardianSetInfo,
     pub guardian_set_expirity: u64,
+
+    pub chain_id: u16,
+    pub fee_denom: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/cosmwasm/contracts/wormhole/tests/integration.rs
+++ b/cosmwasm/contracts/wormhole/tests/integration.rs
@@ -33,9 +33,7 @@ static GOV_ADDR: &[u8] = b"GOVERNANCE_ADDRESS";
 
 fn get_config_info<S: Storage>(storage: &S) -> ConfigInfo {
     let key = to_length_prefixed(CONFIG_KEY);
-    let data = storage
-        .get(&key)
-        .expect("data should exist");
+    let data = storage.get(&key).expect("data should exist");
     from_slice(&data).expect("invalid data")
 }
 
@@ -49,6 +47,8 @@ fn do_init(guardians: &[GuardianAddress]) -> OwnedDeps<MockStorage, MockApi, Moc
             expiration_time: 100,
         },
         guardian_set_expirity: 50,
+        chain_id: 18,
+        fee_denom: "uluna".to_string(),
     };
     let env = mock_env();
     let info = mock_info(INITIALIZER, &[]);
@@ -64,6 +64,8 @@ fn do_init(guardians: &[GuardianAddress]) -> OwnedDeps<MockStorage, MockApi, Moc
             gov_chain: 0,
             gov_address: GOV_ADDR.to_vec(),
             fee: Coin::new(0, "uluna"),
+            chain_id: 18,
+            fee_denom: "uluna".to_string(),
         }
     );
     deps

--- a/cosmwasm/test/src/__tests__/bridge.ts
+++ b/cosmwasm/test/src/__tests__/bridge.ts
@@ -129,6 +129,8 @@ describe("Bridge Tests", () => {
               ],
               expiration_time: 0,
             },
+            chain_id: 18,
+            fee_denom: "uluna"
           },
           "wormhole"
         );
@@ -148,6 +150,7 @@ describe("Bridge Tests", () => {
             gov_address: governanceAddress,
             wormhole_contract: wormhole,
             wrapped_asset_code_id: wrappedAssetCodeId,
+            chain_id: 18,
           },
           "tokenBridge"
         );

--- a/cosmwasm/tools/deploy.js
+++ b/cosmwasm/tools/deploy.js
@@ -165,6 +165,8 @@ addresses["wormhole.wasm"] = await instantiate(
       }),
       expiration_time: 0,
     },
+    chain_id: 18,
+    fee_denom: "uluna",
   },
   "wormhole"
 );
@@ -176,6 +178,7 @@ addresses["token_bridge_terra_2.wasm"] = await instantiate(
     gov_address: Buffer.from(govAddress, "hex").toString("base64"),
     wormhole_contract: addresses["wormhole.wasm"],
     wrapped_asset_code_id: codeIds["cw20_wrapped_2.wasm"],
+    chain_id: 18,
   },
   "tokenBridge"
 );

--- a/cosmwasm/tools/deploy_single.js
+++ b/cosmwasm/tools/deploy_single.js
@@ -151,6 +151,8 @@ async function instantiate(codeId, inst_msg) {
 //     ],
 //     expiration_time: 0,
 //   },
+//   chain_id: 18,
+//   fee_denom: "uluna",
 // });
 
 

--- a/terra/contracts/nft-bridge/src/contract.rs
+++ b/terra/contracts/nft-bridge/src/contract.rs
@@ -100,6 +100,9 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     // Save general wormhole info
+    // TODO: when (if) this contract is adapted to other cosmwasm chains, the
+    // chain id needs to be moved to the state (see the cosmwasm token-bridge
+    // and core bridge contracts).
     let state = ConfigInfo {
         gov_chain: msg.gov_chain,
         gov_address: msg.gov_address.as_slice().to_vec(),


### PR DESCRIPTION
Prior to this change, these values were hardcode in the contract, as
the only supported chain was terra 2. This change allows the contract to
be deployed to other cosmwasm chains without having to recompile the
contract for each one.

The migration code ensures that terra2 is upgraded appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1369)
<!-- Reviewable:end -->
