### PR TITLE
Transfer payload v1 relayer container image

### DIFF
--- a/.github/workflows/relayer-docker.yml
+++ b/.github/workflows/relayer-docker.yml
@@ -1,0 +1,43 @@
+name: Publish transfer payload v1 relayer container image
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: certusone/payloadv1-relayer
+
+jobs:
+  build-and-push-relayer-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./relayer/spy_relayer
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          target: export
+          build-args: GO_BUILD_ARGS=

--- a/relayer/spy_relayer/Dockerfile
+++ b/relayer/spy_relayer/Dockerfile
@@ -11,6 +11,9 @@ RUN apk add python3 \
 
 COPY . .
 
+
+LABEL org.opencontainers.image.source="https://github.com/certusone/wormhole/tree/dev.v2/relayer/spy_relayer#readme"
+
 WORKDIR ./relayer/spy_relayer
 
 RUN npm ci && \


### PR DESCRIPTION
Publishing this (along with [these docs](https://github.com/certusone/wormhole/tree/c5a7d3e517138d1980ff4d379a3a6b10f0c11498/relayer/spy_relayer#relayer) being updated) should make it much easier for wormhole community members or partners to run a relayer.

Once we get this published, I'll add additional documentation on how to run a production version of this relayer in kubernetes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1371)
<!-- Reviewable:end -->
