### PR TITLE
Add wormhole chain to the sdk

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.0
+
+### Added
+
+Wormhole chain devnet support
+
+human-readable part parameter to `humanAddress` function
+
+### Changed
+
+`canonicalAddress` and `humanAddress` functions moved from terra to cosmos module
+
 ## 0.5.2
 
 ### Changed

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "^0.0.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormholenetwork.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js/src/cosmos/address.ts
+++ b/sdk/js/src/cosmos/address.ts
@@ -1,8 +1,8 @@
 import { bech32 } from "bech32";
 
 export function canonicalAddress(humanAddress: string) {
-    return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
+  return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
 }
 export function humanAddress(hrp: string, canonicalAddress: Uint8Array) {
-    return bech32.encode(hrp, bech32.toWords(canonicalAddress));
+  return bech32.encode(hrp, bech32.toWords(canonicalAddress));
 }

--- a/sdk/js/src/cosmos/address.ts
+++ b/sdk/js/src/cosmos/address.ts
@@ -1,0 +1,8 @@
+import { bech32 } from "bech32";
+
+export function canonicalAddress(humanAddress: string) {
+    return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
+}
+export function humanAddress(hrp: string, canonicalAddress: Uint8Array) {
+    return bech32.encode(hrp, bech32.toWords(canonicalAddress));
+}

--- a/sdk/js/src/cosmos/index.ts
+++ b/sdk/js/src/cosmos/index.ts
@@ -1,0 +1,1 @@
+export * from "./address";

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./cosmos";
 export * from "./ethers-contracts";
 export * from "./solana";
 export * from "./terra";
@@ -6,6 +7,7 @@ export * from "./utils";
 export * from "./bridge";
 export * from "./token_bridge";
 
+export * as cosmos from "./cosmos";
 export * as ethers_contracts from "./ethers-contracts";
 export * as solana from "./solana";
 export * as terra from "./terra";

--- a/sdk/js/src/terra/address.ts
+++ b/sdk/js/src/terra/address.ts
@@ -1,12 +1,4 @@
 import { zeroPad } from "@ethersproject/bytes";
-import { bech32 } from "bech32";
-
-export function canonicalAddress(humanAddress: string) {
-  return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
-}
-export function humanAddress(canonicalAddress: Uint8Array) {
-  return bech32.encode("terra", bech32.toWords(canonicalAddress));
-}
 
 // from https://github.com/terra-money/station/blob/dca7de43958ce075c6e46605622203b9859b0e14/src/lib/utils/is.ts#L12
 export const isNativeTerra = (string = "") =>

--- a/sdk/js/src/token_bridge/getOriginalAsset.ts
+++ b/sdk/js/src/token_bridge/getOriginalAsset.ts
@@ -7,7 +7,8 @@ import { decodeLocalState } from "../algorand";
 import { buildTokenId } from "../cosmwasm/address";
 import { TokenImplementation__factory } from "../ethers-contracts";
 import { importTokenWasm } from "../solana/wasm";
-import { buildNativeId, canonicalAddress, isNativeDenom } from "../terra";
+import { buildNativeId, isNativeDenom } from "../terra";
+import { canonicalAddress } from "../cosmos";
 import {
   ChainId,
   ChainName,

--- a/sdk/js/src/utils/array.test.ts
+++ b/sdk/js/src/utils/array.test.ts
@@ -1,6 +1,6 @@
 import { zeroPad } from "ethers/lib/utils";
-import { canonicalAddress } from "../terra";
 import { tryUint8ArrayToNative } from "./array";
+import { canonicalAddress } from "../cosmos";
 
 test("terra address conversion", () => {
   const human = "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";

--- a/sdk/js/src/utils/array.test.ts
+++ b/sdk/js/src/utils/array.test.ts
@@ -1,6 +1,6 @@
 import { zeroPad } from "ethers/lib/utils";
-import { tryUint8ArrayToNative } from "./array";
 import { canonicalAddress } from "../cosmos";
+import { tryUint8ArrayToNative, tryNativeToHexString } from "./array";
 
 test("terra address conversion", () => {
   const human = "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";
@@ -17,4 +17,13 @@ test("terra address conversion", () => {
   const nativeContract = tryUint8ArrayToNative(canonicalContract, "terra2");
   expect(nativeContract).toBe(nativeContract);
   // TODO: native to hex is wrong, which we should correct
+});
+
+test("wormchain address conversion", () => {
+    const human = "wormhole1ap5vgur5zlgys8whugfegnn43emka567dtq0jl";
+    const canonical = "000000000000000000000000e868c4707417d0481dd7e213944e758e776ed35e";
+    const native = tryUint8ArrayToNative(new Uint8Array(Buffer.from(canonical, "hex")), "wormholechain");
+    expect(native).toBe(human);
+
+    expect(tryNativeToHexString(human, "wormholechain")).toBe(canonical)
 });

--- a/sdk/js/src/utils/array.test.ts
+++ b/sdk/js/src/utils/array.test.ts
@@ -20,10 +20,14 @@ test("terra address conversion", () => {
 });
 
 test("wormchain address conversion", () => {
-    const human = "wormhole1ap5vgur5zlgys8whugfegnn43emka567dtq0jl";
-    const canonical = "000000000000000000000000e868c4707417d0481dd7e213944e758e776ed35e";
-    const native = tryUint8ArrayToNative(new Uint8Array(Buffer.from(canonical, "hex")), "wormholechain");
-    expect(native).toBe(human);
+  const human = "wormhole1ap5vgur5zlgys8whugfegnn43emka567dtq0jl";
+  const canonical =
+    "000000000000000000000000e868c4707417d0481dd7e213944e758e776ed35e";
+  const native = tryUint8ArrayToNative(
+    new Uint8Array(Buffer.from(canonical, "hex")),
+    "wormholechain"
+  );
+  expect(native).toBe(human);
 
-    expect(tryNativeToHexString(human, "wormholechain")).toBe(canonical)
+  expect(tryNativeToHexString(human, "wormholechain")).toBe(canonical);
 });

--- a/sdk/js/src/utils/array.ts
+++ b/sdk/js/src/utils/array.ts
@@ -6,8 +6,9 @@ import {
   nativeStringToHexAlgorand,
   uint8ArrayToNativeStringAlgorand,
 } from "../algorand";
+import { canonicalAddress, humanAddress } from "../cosmos"
 import { buildTokenId } from "../cosmwasm/address";
-import { canonicalAddress, humanAddress, isNativeDenom } from "../terra";
+import { isNativeDenom } from "../terra";
 import {
   ChainId,
   ChainName,
@@ -81,9 +82,9 @@ export const tryUint8ArrayToNative = (
     } else {
       if (chainId === CHAIN_ID_TERRA2 && !isLikely20ByteTerra(h)) {
         // terra 2 has 32 byte addresses for contracts and 20 for wallets
-        return humanAddress(a);
+        return humanAddress("terra", a);
       }
-      return humanAddress(a.slice(-20));
+      return humanAddress("terra", a.slice(-20));
     }
   } else if (chainId === CHAIN_ID_ALGORAND) {
     return uint8ArrayToNativeStringAlgorand(a);

--- a/sdk/js/src/utils/array.ts
+++ b/sdk/js/src/utils/array.ts
@@ -6,7 +6,7 @@ import {
   nativeStringToHexAlgorand,
   uint8ArrayToNativeStringAlgorand,
 } from "../algorand";
-import { canonicalAddress, humanAddress } from "../cosmos"
+import { canonicalAddress, humanAddress } from "../cosmos";
 import { buildTokenId } from "../cosmwasm/address";
 import { isNativeDenom } from "../terra";
 import {
@@ -90,8 +90,8 @@ export const tryUint8ArrayToNative = (
   } else if (chainId === CHAIN_ID_ALGORAND) {
     return uint8ArrayToNativeStringAlgorand(a);
   } else if (chainId == CHAIN_ID_WORMHOLE_CHAIN) {
-      // wormhole-chain addresses are always 20 bytes.
-      return humanAddress("wormhole", a.slice(-20));
+    // wormhole-chain addresses are always 20 bytes.
+    return humanAddress("wormhole", a.slice(-20));
   } else if (chainId === CHAIN_ID_NEAR) {
     throw Error("uint8ArrayToNative: Near not supported yet.");
   } else if (chainId === CHAIN_ID_INJECTIVE) {
@@ -211,7 +211,7 @@ export const tryNativeToHexString = (
   } else if (chainId === CHAIN_ID_ALGORAND) {
     return nativeStringToHexAlgorand(address);
   } else if (chainId == CHAIN_ID_WORMHOLE_CHAIN) {
-      return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
+    return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
   } else if (chainId === CHAIN_ID_NEAR) {
     throw Error("hexToNativeString: Near not supported yet.");
   } else if (chainId === CHAIN_ID_INJECTIVE) {

--- a/sdk/js/src/utils/array.ts
+++ b/sdk/js/src/utils/array.ts
@@ -21,6 +21,7 @@ import {
   CHAIN_ID_SOLANA,
   CHAIN_ID_TERRA,
   CHAIN_ID_TERRA2,
+  CHAIN_ID_WORMHOLE_CHAIN,
   CHAIN_ID_UNSET,
   coalesceChainId,
   isEVMChain,
@@ -88,6 +89,9 @@ export const tryUint8ArrayToNative = (
     }
   } else if (chainId === CHAIN_ID_ALGORAND) {
     return uint8ArrayToNativeStringAlgorand(a);
+  } else if (chainId == CHAIN_ID_WORMHOLE_CHAIN) {
+      // wormhole-chain addresses are always 20 bytes.
+      return humanAddress("wormhole", a.slice(-20));
   } else if (chainId === CHAIN_ID_NEAR) {
     throw Error("uint8ArrayToNative: Near not supported yet.");
   } else if (chainId === CHAIN_ID_INJECTIVE) {
@@ -206,6 +210,8 @@ export const tryNativeToHexString = (
     return buildTokenId(address);
   } else if (chainId === CHAIN_ID_ALGORAND) {
     return nativeStringToHexAlgorand(address);
+  } else if (chainId == CHAIN_ID_WORMHOLE_CHAIN) {
+      return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
   } else if (chainId === CHAIN_ID_NEAR) {
     throw Error("hexToNativeString: Near not supported yet.");
   } else if (chainId === CHAIN_ID_INJECTIVE) {

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -26,6 +26,7 @@ export const CHAINS = {
   optimism: 24,
   gnosis: 25,
   ropsten: 10001,
+  wormholechain: 3104,
 } as const;
 
 export type ChainName = keyof typeof CHAINS;
@@ -203,6 +204,11 @@ const MAINNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
+  wormholechain: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
 };
 
 const TESTNET = {
@@ -341,6 +347,11 @@ const TESTNET = {
     core: "0x210c5F5e2AF958B4defFe715Dc621b7a3BA888c5",
     token_bridge: "0xF174F9A837536C449321df1Ca093Bb96948D5386",
     nft_bridge: "0x2b048Da40f69c8dc386a56705915f8E966fe1eba",
+  },
+  wormholechain: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
   },
 };
 
@@ -481,6 +492,11 @@ const DEVNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
+  wormholechain: {
+    core: "wormhole1ap5vgur5zlgys8whugfegnn43emka567dtq0jl",
+    token_bridge: "wormhole1zugu6cajc4z7ue29g9wnes9a5ep9cs7yu7rn3z",
+    nft_bridge: undefined,
+  },
 };
 
 /**
@@ -548,6 +564,7 @@ export const CHAIN_ID_ARBITRUM = CHAINS["arbitrum"];
 export const CHAIN_ID_OPTIMISM = CHAINS["optimism"];
 export const CHAIN_ID_GNOSIS = CHAINS["gnosis"];
 export const CHAIN_ID_ETHEREUM_ROPSTEN = CHAINS["ropsten"];
+export const CHAIN_ID_WORMHOLE_CHAIN = CHAINS["wormholechain"];
 
 // This inverts the [[CHAINS]] object so that we can look up a chain by id
 export type ChainIdToName = {


### PR DESCRIPTION
Add support for wormhole chain to the sdk.  Since the `humanAddress` and `canonicalAddress` functions in the terra package are also needed for wormhole chain, move them into a new cosmos package.  Also, stop hard coding "terra" in `humanAddress` and take the human-readable part as a parameter instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1386)
<!-- Reviewable:end -->
