### PR TITLE
Governor should handle duplicate coin gecko ids

### DIFF
--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -78,7 +78,13 @@ func (gov *ChainGovernor) setTokenForTesting(tokenChainID vaa.ChainID, tokenAddr
 	key := tokenKey{chain: vaa.ChainID(tokenChainID), addr: tokenAddr}
 	te := &tokenEntry{cfgPrice: bigPrice, price: bigPrice, decimals: decimals, symbol: symbol, coinGeckoId: symbol, token: key}
 	gov.tokens[key] = te
-	gov.tokensByCoinGeckoId[symbol] = te
+	cge, cgExists := gov.tokensByCoinGeckoId[te.coinGeckoId]
+	if !cgExists {
+		gov.tokensByCoinGeckoId[te.coinGeckoId] = []*tokenEntry{te}
+	} else {
+		cge = append(cge, te)
+		gov.tokensByCoinGeckoId[te.coinGeckoId] = cge
+	}
 	return nil
 }
 


### PR DESCRIPTION
The governor was not properly handling the case where there are multiple tokens using the same CoinGecko symbol.

The governor previously had a map from CoinGecko symbol to a reference to a token object. The change is to make that a map from the CoinGecko symbol to an array of references to tokens, and to update all of those tokens when the CoinGecko price is udpated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1418)
<!-- Reviewable:end -->
