### PR TITLE
add EVM contract for batched VAA development

### DIFF
--- a/devnet/eth-devnet.yaml
+++ b/devnet/eth-devnet.yaml
@@ -53,7 +53,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "npm run migrate && npx truffle exec scripts/deploy_test_token.js && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && nc -lkp 2000 0.0.0.0"
+            - "npm run migrate && npm run deploy-batched-vaa-sender && npx truffle exec scripts/deploy_test_token.js && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && nc -lkp 2000 0.0.0.0"
           readinessProbe:
             periodSeconds: 1
             failureThreshold: 300

--- a/devnet/eth-devnet.yaml
+++ b/devnet/eth-devnet.yaml
@@ -53,7 +53,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "npm run migrate && npm run deploy-batched-vaa-sender && npx truffle exec scripts/deploy_test_token.js && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && nc -lkp 2000 0.0.0.0"
+            - "npm run migrate && npx truffle exec scripts/deploy_test_token.js && npm run deploy-batched-vaa-sender && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && nc -lkp 2000 0.0.0.0"
           readinessProbe:
             periodSeconds: 1
             failureThreshold: 300

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -57,3 +57,13 @@ wormhole/ethereum $ ../scripts/install-foundry
 ```
 
 The installer script installs foundry and the appropriate solc version to build the contracts.
+
+### Batched VAAs
+
+To send a transaction that will create multiple VAAs, invoke the `sendMultipleMessages` method of [ethereum/contracts/mock/MockBatchedVAASender.sol](./contracts/mock/MockBatchedVAASender.sol) with the truffle script:
+
+    npx truffle exec scripts/send_batched_vaa.js
+
+or invoke the same script in the tilt devnet:
+
+    minikube kubectl -- exec -n wormhole eth-devnet-0 -c tests --  npx truffle exec scripts/send_batched_vaa.js

--- a/ethereum/contracts/mock/MockBatchedVAASender.sol
+++ b/ethereum/contracts/mock/MockBatchedVAASender.sol
@@ -1,0 +1,53 @@
+// contracts/mock/MockBatchedVAASender.sol
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "../libraries/external/BytesLib.sol";
+import "../interfaces/IWormhole.sol";
+
+contract MockBatchedVAASender {
+    using BytesLib for bytes;
+
+    address wormholeCoreAddress;
+
+    function sendMultipleMessages(
+        uint32 nonce,
+        bytes memory payload,
+        uint8 consistencyLevel
+    )
+        public
+        payable
+        returns (
+            uint64 messageSequence0,
+            uint64 messageSequence1,
+            uint64 messageSequence2
+        )
+    {
+        messageSequence0 = wormholeCore().publishMessage{value: msg.value}(
+            nonce,
+            payload,
+            consistencyLevel
+        );
+
+        messageSequence1 = wormholeCore().publishMessage{value: msg.value}(
+            nonce,
+            payload,
+            consistencyLevel
+        );
+
+        messageSequence2 = wormholeCore().publishMessage{value: msg.value}(
+            nonce,
+            payload,
+            consistencyLevel
+        );
+    }
+
+    function wormholeCore() private view returns (IWormhole) {
+        return IWormhole(wormholeCoreAddress);
+    }
+
+    function setup(address _wormholeCore) public {
+        wormholeCoreAddress = _wormholeCore;
+    }
+}

--- a/ethereum/migrations/10_deploy_batched_vaa_sender.js
+++ b/ethereum/migrations/10_deploy_batched_vaa_sender.js
@@ -1,0 +1,15 @@
+require('dotenv').config({ path: "../.env" });
+
+const Wormhole = artifacts.require("Wormhole");
+const MockBatchedVAASender = artifacts.require("MockBatchedVAASender");
+
+module.exports = async function (deployer, network, accounts) {
+
+    await deployer.deploy(MockBatchedVAASender)
+
+    const contract = new web3.eth.Contract(MockBatchedVAASender.abi, MockBatchedVAASender.address);
+
+    await contract.methods.setup(
+        Wormhole.address
+    ).send({from: accounts[0]})
+};

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -25,6 +25,7 @@
     "deploy-bridge-implementation-only": "mkdir -p build/contracts && cp node_modules/@openzeppelin/contracts/build/contracts/* build/contracts/ && truffle migrate --f 6 --to 6",
     "deploy-read-only": "mkdir -p build/contracts && cp node_modules/@openzeppelin/contracts/build/contracts/* build/contracts/ && truffle migrate --f 1 --to 2",
     "deploy_weth9": "mkdir -p build/contracts && cp node_modules/@openzeppelin/contracts/build/contracts/* build/contracts/ && truffle migrate --f 9",
+    "deploy-batched-vaa-sender": "mkdir -p build/contracts && cp node_modules/@openzeppelin/contracts/build/contracts/* build/contracts/ && truffle migrate --f 10 --to 10",
     "verify": "patch -u -f node_modules/truffle-plugin-verify/constants.js -i truffle-verify-constants.patch; truffle run verify $npm_config_module@$npm_config_contract_address --network $npm_config_network",
     "verify-token": "patch -u -f node_modules/truffle-plugin-verify/constants.js -i truffle-verify-constants.patch; truffle run verify BridgeToken@$npm_config_contract_address --forceConstructorArgs string:$npm_config_constructor_args --network $npm_config_network",
     "abigen": "truffle run abigen"

--- a/ethereum/scripts/deploy_batched_vaa_sender.js
+++ b/ethereum/scripts/deploy_batched_vaa_sender.js
@@ -7,6 +7,11 @@ module.exports = async function(callback) {
 
     await MockBatchedVAASender.deploy();
 
+    // devnet contract address should be deterministic
+    if (MockBatchedVAASender.address !== "0xf19a2a01b70519f67adb309a994ec8c69a967e8b") {
+      throw new Error("unexpected batched-VAA contract address");
+    }
+
     const batchedSender = new web3.eth.Contract(MockBatchedVAASender.abi, MockBatchedVAASender.address);
     await batchedSender.methods.setup(Wormhole.address).send({from: accounts[0]});
 

--- a/ethereum/scripts/deploy_batched_vaa_sender.js
+++ b/ethereum/scripts/deploy_batched_vaa_sender.js
@@ -1,0 +1,17 @@
+const Wormhole = artifacts.require("Wormhole");
+const MockBatchedVAASender = artifacts.require("MockBatchedVAASender");
+
+module.exports = async function(callback) {
+  try {
+    const accounts = await web3.eth.getAccounts();
+
+    await MockBatchedVAASender.deploy();
+
+    const batchedSender = new web3.eth.Contract(MockBatchedVAASender.abi, MockBatchedVAASender.address);
+    await batchedSender.methods.setup(Wormhole.address).send({from: accounts[0]});
+
+    callback();
+  } catch (e) {
+    callback(e);
+  }
+};

--- a/ethereum/scripts/send_batched_vaa.js
+++ b/ethereum/scripts/send_batched_vaa.js
@@ -1,0 +1,29 @@
+const MockBatchedVAASender = artifacts.require("MockBatchedVAASender");
+
+module.exports = async function(callback) {
+  try {
+    const accounts = await web3.eth.getAccounts();
+
+    const batchedSender = await MockBatchedVAASender.deployed()
+
+    const contract = new web3.eth.Contract(MockBatchedVAASender.abi, batchedSender.address);
+
+    const nonce = Math.round(Date.now() / 1000);
+    const nonceHex = nonce.toString(16)
+
+    const res = await contract.methods.sendMultipleMessages(
+      "0x" + nonceHex,
+      "0x1",
+      32
+    ).send({
+      value: 0,
+      from: accounts[0]
+    });
+
+    console.log('sendMultipleMessages response', res)
+
+    callback();
+  } catch (e) {
+    callback(e);
+  }
+};


### PR DESCRIPTION
Added an EVM contract that calls wormhole core's `publishMessage` several times, in order to produce VAAs that should be batched.

Also added a truffle script that invokes the new contract's method, and some tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1425)
<!-- Reviewable:end -->
