### PR TITLE
node: don't allow obs reqs if the queue is full

### DIFF
--- a/node/cmd/guardiand/adminserver.go
+++ b/node/cmd/guardiand/adminserver.go
@@ -396,7 +396,10 @@ func adminServiceRunnable(logger *zap.Logger, socketPath string, injectC chan<- 
 }
 
 func (s *nodePrivilegedService) SendObservationRequest(ctx context.Context, req *nodev1.SendObservationRequestRequest) (*nodev1.SendObservationRequestResponse, error) {
-	s.obsvReqSendC <- req.ObservationRequest
+	if err := common.PostObservationRequest(s.obsvReqSendC, req.ObservationRequest); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info("sent observation request", zap.Any("request", req.ObservationRequest))
 	return &nodev1.SendObservationRequestResponse{}, nil
 }

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -793,10 +793,10 @@ func runNode(cmd *cobra.Command, args []string) {
 	signedInC := make(chan *gossipv1.SignedVAAWithQuorum, 50)
 
 	// Inbound observation requests from the p2p service (for all chains)
-	obsvReqC := make(chan *gossipv1.ObservationRequest, 50)
+	obsvReqC := make(chan *gossipv1.ObservationRequest, common.ObsvReqChannelSize)
 
 	// Outbound observation requests
-	obsvReqSendC := make(chan *gossipv1.ObservationRequest)
+	obsvReqSendC := make(chan *gossipv1.ObservationRequest, common.ObsvReqChannelSize)
 
 	// Injected VAAs (manually generated rather than created via observation)
 	injectC := make(chan *vaa.VAA)

--- a/node/pkg/common/obsvReqSendC.go
+++ b/node/pkg/common/obsvReqSendC.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"fmt"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+)
+
+const ObsvReqChannelSize = 50
+const ObsvReqChannelFullError = "channel is full"
+
+func PostObservationRequest(obsvReqSendC chan *gossipv1.ObservationRequest, req *gossipv1.ObservationRequest) error {
+	if len(obsvReqSendC) >= cap(obsvReqSendC) {
+		return fmt.Errorf(ObsvReqChannelFullError)
+	}
+
+	obsvReqSendC <- req
+	return nil
+}


### PR DESCRIPTION
Change-Id: Ifb0d038fa3adeddc6226e2289fe9dbfc8e39b4e7

Jeff noticed a while ago that too many reobservation requests can hang the guardian. This is because an attempt to write to the channel hangs if the channel has reached capacity. This PR addresses by making sure the channel is not full before writing to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1429)
<!-- Reviewable:end -->
