### PR TITLE
cosmwasm: Expose 'is VAA redeemed' query

### DIFF
--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -77,6 +77,7 @@ use crate::{
         ExecuteMsg,
         ExternalIdResponse,
         InstantiateMsg,
+        IsVaaRedeemedResponse,
         MigrateMsg,
         QueryMsg,
         TransferInfoResponse,
@@ -1456,6 +1457,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::TransferInfo { vaa } => to_binary(&query_transfer_info(deps, env, &vaa)?),
         QueryMsg::ExternalId { external_id } => to_binary(&query_external_id(deps, external_id)?),
+        QueryMsg::IsVaaRedeemed { vaa } => to_binary(&query_is_vaa_redeemed(deps, env, &vaa)?),
     }
 }
 
@@ -1524,6 +1526,13 @@ fn query_transfer_info(deps: Deps, env: Env, vaa: &Binary) -> StdResult<Transfer
         }
         other => Err(StdError::generic_err(format!("Invalid action: {}", other))),
     }
+}
+
+fn query_is_vaa_redeemed(deps: Deps, _env: Env, vaa: &Binary) -> StdResult<IsVaaRedeemedResponse> {
+    let vaa = ParsedVAA::deserialize(vaa)?;
+    Ok(IsVaaRedeemedResponse {
+        is_redeemed: vaa_archive_check(deps.storage, vaa.hash.as_slice()),
+    })
 }
 
 fn is_governance_emitter(cfg: &ConfigInfo, emitter_chain: u16, emitter_address: &[u8]) -> bool {

--- a/cosmwasm/contracts/token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/token-bridge/src/msg.rs
@@ -87,6 +87,7 @@ pub enum QueryMsg {
     WrappedRegistry { chain: u16, address: Binary },
     TransferInfo { vaa: Binary },
     ExternalId { external_id: Binary },
+    IsVaaRedeemed { vaa: Binary },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -111,4 +112,10 @@ pub struct TransferInfoResponse {
 #[serde(rename_all = "snake_case")]
 pub struct ExternalIdResponse {
     pub token_id: TokenId,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct IsVaaRedeemedResponse {
+    pub is_redeemed: bool,
 }

--- a/sdk/js/src/token_bridge/__tests__/terra2-integration.ts
+++ b/sdk/js/src/token_bridge/__tests__/terra2-integration.ts
@@ -14,6 +14,7 @@ import {
   getEmitterAddressEth,
   getEmitterAddressTerra,
   getIsTransferCompletedTerra,
+  getIsTransferCompletedTerra2,
   parseSequenceFromLogEth,
   parseSequenceFromLogTerra,
   redeemOnEth,
@@ -32,7 +33,6 @@ import { approveEth, transferFromEth, transferFromTerra } from "../transfer";
 import {
   ETH_NODE_URL,
   ETH_PRIVATE_KEY2,
-  TERRA2_GAS_PRICES_URL,
   TERRA2_NODE_URL,
   TERRA2_PRIVATE_KEY,
   TERRA_CHAIN_ID,
@@ -207,13 +207,19 @@ test("Attest and transfer token from Ethereum to Terra2", async () => {
     terraWalletAddress,
     transferSignedVaa
   );
-  await terraBroadcastAndWaitForExecution([redeemMsg], terraWallet);
   expect(
-    await getIsTransferCompletedTerra(
+    await getIsTransferCompletedTerra2(
       CONTRACTS.DEVNET.terra2.token_bridge,
       transferSignedVaa,
       lcd,
-      TERRA2_GAS_PRICES_URL
+    )
+  ).toBe(false);
+  await terraBroadcastAndWaitForExecution([redeemMsg], terraWallet);
+  expect(
+    await getIsTransferCompletedTerra2(
+      CONTRACTS.DEVNET.terra2.token_bridge,
+      transferSignedVaa,
+      lcd,
     )
   ).toBe(true);
 });


### PR DESCRIPTION
The `getIsTransferCompleted*`  family of functions in the js sdk that query cosmwasm functions (terra1, terra2, and soon injective) require simulating a redeem transaction to see if they fail with `VAAAlreadyExecuted`  to determine whether the VAA in question has already been redeemed.
This is obviously suboptimal -- this PR introduces a first class query to the cosmwasm token bridge contract so that this information can just be queried without requiring a signer and a tx simulation.
There's an accompanying sdk function to query this information for terra2. No such contract change or sdk change has been made for terra classic, and it might not be worth doing it anyway. Open to discussion though.

### Left to do
- [ ] Add changelog entry to sdk

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1430)
<!-- Reviewable:end -->
