### PR TITLE
node: Deduplicate re-observation requests

### DIFF
--- a/node/cmd/guardiand/reobserve.go
+++ b/node/cmd/guardiand/reobserve.go
@@ -1,0 +1,71 @@
+package guardiand
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/vaa"
+	"go.uber.org/zap"
+)
+
+// Multiplex observation requests to the appropriate chain
+func handleReobservationRequests(
+	ctx context.Context,
+	clock clock.Clock,
+	logger *zap.Logger,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	chainObsvReqC map[vaa.ChainID]chan *gossipv1.ObservationRequest,
+) {
+	// Due to the automatic re-observation requests sent out by the processor we may end
+	// up getting multiple requests to re-observe the same tx. Keep a cache of the
+	// requests received in the last 11 minutes so that we don't end up repeatedly
+	// re-observing the same transactions.
+	type cachedRequest struct {
+		chainId vaa.ChainID
+		txHash  string
+	}
+
+	cache := make(map[cachedRequest]time.Time)
+	ticker := clock.Ticker(7 * time.Minute)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := clock.Now()
+			for r, t := range cache {
+				if now.Sub(t) > 11*time.Minute {
+					delete(cache, r)
+				}
+			}
+		case req := <-obsvReqC:
+			r := cachedRequest{
+				chainId: vaa.ChainID(req.ChainId),
+				txHash:  hex.EncodeToString(req.TxHash),
+			}
+
+			if _, ok := cache[r]; ok {
+				// We've recently seen a re-observation request for this tx
+				// so skip this one.
+				logger.Info("skipping duplicate re-observation request",
+					zap.Stringer("chain", r.chainId),
+					zap.String("tx_hash", r.txHash),
+				)
+				continue
+			}
+
+			cache[r] = clock.Now()
+
+			if channel, ok := chainObsvReqC[r.chainId]; ok {
+				channel <- req
+			} else {
+				logger.Error("unknown chain ID for reobservation request",
+					zap.Uint16("chain_id", uint16(r.chainId)),
+					zap.String("tx_hash", r.txHash))
+			}
+		}
+	}
+}

--- a/node/cmd/guardiand/reobserve_test.go
+++ b/node/cmd/guardiand/reobserve_test.go
@@ -1,0 +1,179 @@
+package guardiand
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/vaa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type reobservationTestContext struct {
+	context.Context
+	clock         *clock.Mock
+	obsvReqC      chan *gossipv1.ObservationRequest
+	chainObsvReqC map[vaa.ChainID]chan *gossipv1.ObservationRequest
+}
+
+func setUpReobservationTest() (reobservationTestContext, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	clock := clock.NewMock()
+
+	obsvReqC := make(chan *gossipv1.ObservationRequest)
+
+	chainObsvReqC := make(map[vaa.ChainID]chan *gossipv1.ObservationRequest)
+	for i := 0; i < 10; i++ {
+		chainObsvReqC[vaa.ChainID(i)] = make(chan *gossipv1.ObservationRequest)
+	}
+
+	go handleReobservationRequests(ctx, clock, zap.NewNop(), obsvReqC, chainObsvReqC)
+
+	tc := reobservationTestContext{
+		Context:       ctx,
+		clock:         clock,
+		obsvReqC:      obsvReqC,
+		chainObsvReqC: chainObsvReqC,
+	}
+	return tc, cancel
+}
+
+func readFromChannel(parent context.Context, c <-chan *gossipv1.ObservationRequest) (*gossipv1.ObservationRequest, bool) {
+	ctx, cancel := context.WithTimeout(parent, 50*time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		return nil, false
+	case r := <-c:
+		return r, true
+	}
+}
+
+func TestReobservationRequest(t *testing.T) {
+	ctx, cancel := setUpReobservationTest()
+	defer cancel()
+
+	req := &gossipv1.ObservationRequest{
+		ChainId: 1,
+		TxHash:  []byte{0xe5, 0x9c, 0x1b, 0xe5, 0x0b, 0xe7, 0xe4, 0x7e},
+	}
+
+	ctx.obsvReqC <- req
+
+	actual, ok := readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+
+	assert.Equal(t, req, actual)
+}
+
+func TestDuplicateReobservation(t *testing.T) {
+	ctx, cancel := setUpReobservationTest()
+	defer cancel()
+
+	req := &gossipv1.ObservationRequest{
+		ChainId: 1,
+		TxHash:  []byte{0xe5, 0x9c, 0x1b, 0xe5, 0x0b, 0xe7, 0xe4, 0x7e},
+	}
+
+	ctx.obsvReqC <- req
+
+	actual, ok := readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+
+	// Receiving the same request again should not trigger another re-observation.
+	ctx.obsvReqC <- req
+
+	_, ok = readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	assert.False(t, ok)
+}
+
+func TestMultipleReobservations(t *testing.T) {
+	ctx, cancel := setUpReobservationTest()
+	defer cancel()
+
+	req := &gossipv1.ObservationRequest{
+		ChainId: 1,
+		TxHash:  []byte{0xe5, 0x9c, 0x1b, 0xe5, 0x0b, 0xe7, 0xe4, 0x7e},
+	}
+
+	ctx.obsvReqC <- req
+
+	actual, ok := readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+
+	// Send a request for the same chain id but different tx hash.
+	req.TxHash = []byte{0x6e, 0xf0, 0xa6, 0xba, 0x47, 0x3d, 0x34, 0x51}
+
+	ctx.obsvReqC <- req
+
+	actual, ok = readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+
+	// Send a request for the same tx hash but different chain id.
+	req.ChainId = 3
+	ctx.obsvReqC <- req
+
+	actual, ok = readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+}
+
+func TestReobserveUnknownChainId(t *testing.T) {
+	ctx, cancel := setUpReobservationTest()
+	defer cancel()
+
+	req := &gossipv1.ObservationRequest{
+		ChainId: uint32(len(ctx.chainObsvReqC)) + 1,
+		TxHash:  []byte{0xe5, 0x9c, 0x1b, 0xe5, 0x0b, 0xe7, 0xe4, 0x7e},
+	}
+
+	ctx.obsvReqC <- req
+
+	_, ok := readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	assert.False(t, ok)
+}
+
+func TestReobservationCacheEviction(t *testing.T) {
+	ctx, cancel := setUpReobservationTest()
+	defer cancel()
+
+	req := &gossipv1.ObservationRequest{
+		ChainId: 1,
+		TxHash:  []byte{0xe5, 0x9c, 0x1b, 0xe5, 0x0b, 0xe7, 0xe4, 0x7e},
+	}
+
+	ctx.obsvReqC <- req
+
+	actual, ok := readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+
+	// Advance the clock by 7.5 minutes, which should trigger the ticker but not cause eviction.
+	ctx.clock.Add(7*time.Minute + 30*time.Second)
+
+	// Receiving the same request again should not trigger another re-observation.
+	ctx.obsvReqC <- req
+
+	_, ok = readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	assert.False(t, ok)
+
+	// Advance the clock by another 7 minutes, which should evict the re-observation request
+	// from the cache.
+	ctx.clock.Add(7 * time.Minute)
+
+	// This time the request should be passed through.
+	ctx.obsvReqC <- req
+
+	actual, ok = readFromChannel(ctx, ctx.chainObsvReqC[vaa.ChainID(req.ChainId)])
+	require.True(t, ok)
+	assert.Equal(t, req, actual)
+}


### PR DESCRIPTION
Commit "1753bb3: Send re-observation request when re-broadcasting local
observations" changed the processor code to automatically send
re-observation requests.  If multiple guardians do this around the same
time that would lead to multiple re-observation requests for the same
transaction.

Deduplicate re-observation requests by keeping a cache of the requests
that were received in the last 11 minutes.  Any request that's already
in the cache will not be forwarded to the chain-specific observation
code.  The 11 minute value was chosen because the guardians will send
these requests approximately every 5 minutes.

Also move the re-observation code into a standalone function so that it
can be more easily tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1462)
<!-- Reviewable:end -->
